### PR TITLE
Allow some clippy lints that complain about common bevy code

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,7 +70,7 @@ jobs:
         uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: -- -D warnings -Aclippy::type_complexity -Aclippy::too_many_arguments
+          args: -- -D warnings
 
   # Run cargo fmt --all -- --check
   format:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,6 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-
   # Run cargo test
   test:
     name: Test Suite
@@ -71,7 +70,7 @@ jobs:
         uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: -- -D warnings
+          args: -- -D warnings -Aclippy::type_complexity -Aclippy::too_many_arguments
 
   # Run cargo fmt --all -- --check
   format:

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::too_many_arguments, clippy::type_complexity)]
+
 use bevy::prelude::*;
 
 fn main() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,7 @@
+// Bevy code commonly triggers these lints and they may be important signals
+// about code quality. They are sometimes hard to avoid though, and the CI
+// workflow treats them as errors, so this allows them throughout the project.
+// Feel free to delete this line.
 #![allow(clippy::too_many_arguments, clippy::type_complexity)]
 
 use bevy::prelude::*;


### PR DESCRIPTION
It's pretty common when writing bevy code to create complex types or systems with a lot of arguments.

Users may just ignore these lints locally if they use clippy at all. But the current CI setup would then fail and force the user to dig into the workflows which may be rather arcane to a user unaccustomed to using github workflows.

I think that these defaults might be better for new users. Bevy itself allows `type_complexity` in CI and allows `too_many_arguments` in many files in the repo.