### PR TITLE
Install zld when compiling for macOS if required

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,6 +9,7 @@ env:
   # update with the name of the main binary
   binary: bevy_github_ci_template
   add_binaries_to_github_release: true
+  is_lld_configured: false
   #itch_target: <itch.io-username>/<game-name>
 
 
@@ -155,7 +156,7 @@ jobs:
 
   # Build for macOS
   release-macos:
-    runs-on: macOS-latest
+    runs-on: macos-latest
 
     steps:
       - uses: little-core-labs/get-git-tag@v3.0.1
@@ -170,6 +171,9 @@ jobs:
         run: |
           export CFLAGS="-fno-stack-check"
           export MACOSX_DEPLOYMENT_TARGET="10.9"
+      - name: Install zld
+        if: ${{ env.is_lld_configured == 'true' }}
+        run: brew install michaeleisel/zld/zld
 
       - name: Build
         run: |

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ If you would like to use the GitHub workflows included here for your own project
    1. Either create one and put a `.gitkeep` file in it to be able to push it
    2. Or remove the `cp -r assets` statements in the build jobs
 4. Adapt the used toolchain if you are using nightly
+5. If you have enabled [fast compile optimizations](https://bevyengine.org/learn/book/getting-started/setup/#enable-fast-compiles-optional) with lld, make sure to change `is_lld_enabled` to true at [.github/workflows/release.yaml](./.github/workflows/release.yaml) so that it compiles on macOS.
 
 ### Publish on itch.io
 


### PR DESCRIPTION
### Description

When LLD is set as a linker, the macOS release step fails since it requires zld.

### Implementation

* Added a flag on the release action to set if LLD was configured (false by default). It installs `zld` from brew on the macos step.
* Documented it at the README.

Although this gets the job done, the .cargo/ directory could be read to automatically determine if LLD is being use, withou the need of a flag, what do you think?