### PR TITLE
restart audio context on interactions

### DIFF
--- a/wasm/index.html
+++ b/wasm/index.html
@@ -1,11 +1,12 @@
 <!doctype html>
 <html lang="en">
-<script type="module">
-  import init from './bevy_game.js'
-  init()
-</script>
 
 <body style="margin: 0px;">
+  <script type="module">
+    import './restart-audio-context.js'
+    import init from './bevy_game.js'
+    init()
+  </script>
 </body>
 
 </html>

--- a/wasm/restart-audio-context.js
+++ b/wasm/restart-audio-context.js
@@ -1,0 +1,57 @@
+// taken from https://developer.chrome.com/blog/web-audio-autoplay/#moving-forward
+(function () {
+    // An array of all contexts to resume on the page
+    const audioContextList = [];
+
+    // An array of various user interaction events we should listen for
+    const userInputEventNames = [
+        'click',
+        'contextmenu',
+        'auxclick',
+        'dblclick',
+        'mousedown',
+        'mouseup',
+        'pointerup',
+        'touchend',
+        'keydown',
+        'keyup',
+    ];
+
+    // A proxy object to intercept AudioContexts and
+    // add them to the array for tracking and resuming later
+    self.AudioContext = new Proxy(self.AudioContext, {
+        construct(target, args) {
+            const result = new target(...args);
+            audioContextList.push(result);
+            return result;
+        },
+    });
+
+    // To resume all AudioContexts being tracked
+    function resumeAllContexts(event) {
+        let count = 0;
+
+        audioContextList.forEach(context => {
+            if (context.state !== 'running') {
+                context.resume();
+            } else {
+                count++;
+            }
+        });
+
+        // If all the AudioContexts have now resumed then we
+        // unbind all the event listeners from the page to prevent
+        // unnecessary resume attempts
+        if (count == audioContextList.length) {
+            userInputEventNames.forEach(eventName => {
+                document.removeEventListener(eventName, resumeAllContexts);
+            });
+        }
+    }
+
+    // We bind the resume function for each user interaction
+    // event on the page
+    userInputEventNames.forEach(eventName => {
+        document.addEventListener(eventName, resumeAllContexts);
+    });
+})();


### PR DESCRIPTION
- Fixes https://github.com/bevyengine/bevy_github_ci_template/issues/17
- The errors about audio context still show up in the console on the initial load. 
- Without this PR the bevy audio example never will play the audio after a refresh, but with this the song starts playing after an interaction with the page.