### PR TITLE
Resolves warnings related to Node.js 12 and set-output being deprecated

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Cache
         uses: actions/cache@v2
         with:
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Cache
         uses: actions/cache@v2
         with:
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,9 +19,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: little-core-labs/get-git-tag@v3.0.1
+      - uses: olegtarasov/get-tag@v2.1.2
         id: get_version
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown
@@ -64,9 +64,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: little-core-labs/get-git-tag@v3.0.1
+      - uses: olegtarasov/get-tag@v2.1.2
         id: get_version
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: x86_64-unknown-linux-gnu
@@ -110,9 +110,9 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: little-core-labs/get-git-tag@v3.0.1
+      - uses: olegtarasov/get-tag@v2.1.2
         id: get_version
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: x86_64-pc-windows-msvc
@@ -152,9 +152,9 @@ jobs:
     runs-on: macOS-latest
 
     steps:
-      - uses: little-core-labs/get-git-tag@v3.0.1
+      - uses: olegtarasov/get-tag@v2.1.2
         id: get_version
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: x86_64-apple-darwin
@@ -198,9 +198,9 @@ jobs:
       - id: check-env
         run: |
           if [[ -z "$itch_target" ]]; then
-            echo "::set-output name=has-itch-target::no"
+            echo "has-itch-target=no" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=has-itch-target::yes"
+            echo "has-itch-target=yes" >> $GITHUB_OUTPUT
           fi
 
   upload-to-itch:
@@ -225,7 +225,7 @@ jobs:
           unzip butler.zip
           chmod +x butler
           ./butler -V
-      - uses: little-core-labs/get-git-tag@v3.0.1
+      - uses: olegtarasov/get-tag@v2.1.2
         id: get_version
       - name: Upload to itch.io
         env:


### PR DESCRIPTION
This pull request is a minor change to the overall template that upgrades 1 library, changes 1 library to an identical upstream one, and changes some syntax but is ultimately identical in function.

Due to `set-output` being deprecated this uses `echo "has-itch-target=no" >> $GITHUB_OUTPUT` instead as recommended by the warning in github actions.

Due to Node.js 12 no longer being supported this also upgrades `actions/checkout@v2` to `actions/checkout@v3` which uses Node.js 16 and `little-core-labs/get-git-tag@v3.0.1` is changed to `olegtarasov/get-tag@v2.1.2`. `little-core-labs/get-git-tag` is originally a branch of `olegtarasov/get-tag` so they have nearly identical functionality. The main reason to switch back to the upstream library is that `little-core-labs/get-git-tag` has not been updated in a year and hasn't been updated to support Node.js 16 in comparison to `olegtarasov/get-tag` which has.

This pull request doesn't change anything in regards to functionality and instead only future proofs this template for later use.