### PR TITLE
Update CI actions/cache@v2 to v3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
       - name: Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/bin/
@@ -42,7 +42,7 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
       - name: Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/bin/


### PR DESCRIPTION
Node.js 12 actions are deprecated and actions/cache@v3 uses Node.js 16.

Deprecation warning is gone after update.
The same was done for the checkout action in #31