### PR TITLE
Only keep release artifacts for one day

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,6 +48,7 @@ jobs:
         with:
           path: ${{ env.binary }}.zip
           name: wasm
+          retention-days: 1
 
       - name: Upload binaries to release
         if: ${{ env.add_binaries_to_github_release == 'true' }}
@@ -94,6 +95,7 @@ jobs:
         with:
           path: ${{ env.binary }}.zip
           name: linux
+          retention-days: 1
 
       - name: Upload binaries to release
         if: ${{ env.add_binaries_to_github_release == 'true' }}
@@ -136,6 +138,7 @@ jobs:
         with:
           path: ${{ env.binary }}.zip
           name: windows
+          retention-days: 1
 
       - name: Upload binaries to release
         if: ${{ env.add_binaries_to_github_release == 'true' }}
@@ -179,6 +182,7 @@ jobs:
         with:
           path: ${{ env.binary }}-macOS-intel.dmg
           name: macOS-intel
+          retention-days: 1
 
       - name: Upload binaries to release
         if: ${{ env.add_binaries_to_github_release == 'true' }}
@@ -222,6 +226,7 @@ jobs:
         with:
           path: ${{ env.binary }}-macOS-apple-silicon.dmg
           name: macOS-apple-silicon
+          retention-days: 1
 
       - name: Upload binaries to release
         if: ${{ env.add_binaries_to_github_release == 'true' }}


### PR DESCRIPTION
By default artifacts are retained for three months. Considering how the only thing that looks at them is the `upload-to-itch` job, which will run immediately after, this seems wasteful. One day is enough (we probably don't even need a whole day, but that's the minimum)