### PR TITLE
Add exception handler to filter out winit control flow message

### DIFF
--- a/wasm/index.html
+++ b/wasm/index.html
@@ -5,7 +5,12 @@
   <script type="module">
     import './restart-audio-context.js'
     import init from './bevy_game.js'
-    init()
+
+    init().catch((error) => {
+      if (!error.message.startsWith("Using exceptions for control flow, don't mind me. This isn't actually an error!")) {
+        throw error;
+      }
+    });
   </script>
 </body>
 


### PR DESCRIPTION
During startup winit is using an exception as a part of its control flow. This exception is "normal" and not a actual error but will end up polluting the users browser console. 

Add a simple catch all exceptions method that will silently drop this exception and propagate all other exceptions.