### PR TITLE
Improve release workflow and readme

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-
+  workflow_dispatch:
+  
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches: [main]
   workflow_dispatch:
-  
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/github_pages.yaml
+++ b/.github/workflows/github_pages.yaml
@@ -1,0 +1,19 @@
+name: Publish Github-Pages
+
+on:
+  workflow_call:
+
+jobs:
+  publish-github-pages:
+    name: github-pages
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/.github/workflows/github_releases.yaml
+++ b/.github/workflows/github_releases.yaml
@@ -1,0 +1,49 @@
+name: Publish Github-Releases
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        required: true
+        type: string
+      os:
+        required: true
+        type: string
+      artifact_name:
+        required: true
+        type: string
+
+jobs:
+  github-releases:
+    name: ${{ inputs.artifact_name }}
+    runs-on: ${{ inputs.os }}
+    steps:
+      - uses: xSAVIKx/artifact-exists-action@v0
+        id: check_artifact
+        with:
+          name: ${{ inputs.artifact_name }}
+
+      - name: Download artifacts
+        if: steps.check_artifact.outputs.exists == 'true'
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ inputs.artifact_name }}
+          path: ./artifact
+
+      - name: Get file
+        if: steps.check_artifact.outputs.exists == 'true'
+        id: get_file_name
+        shell: bash
+        working-directory: ./artifact
+        run: |
+          ls -R
+          echo "file_name=$(ls | head -n 1)" >> "$GITHUB_OUTPUT"
+
+      - name: Upload artifact to release
+        if: steps.check_artifact.outputs.exists == 'true'
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ./artifact/${{ steps.get_file_name.outputs.file_name }}
+          tag: ${{ inputs.tag }}
+          overwrite: true

--- a/.github/workflows/itchio.yaml
+++ b/.github/workflows/itchio.yaml
@@ -1,0 +1,43 @@
+name: Publish Itch.io
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        required: true
+        type: string
+      itchio_target:
+        required: true
+        type: string
+
+jobs:
+  publish-itchio:
+    name: itchio
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          path: ./builds
+
+      - name: Install butler
+        run: |
+          curl -L -o butler.zip https://broth.itch.ovh/butler/linux-amd64/LATEST/archive/default
+          unzip butler.zip
+          chmod +x butler
+          ./butler -V
+
+      - name: Upload to itch.io
+        env:
+          BUTLER_API_KEY: ${{ secrets.BUTLER_CREDENTIALS }}
+        run: |
+          for channel in $(ls builds); do
+            if [ "$channel" = "github-pages" ]; then
+              continue
+            fi
+            ./butler push \
+              --fix-permissions \
+              --userversion="${{ inputs.tag }}" \
+              builds/$channel/* \
+              ${{ inputs.itchio_target }}:$channel
+          done

--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -1,0 +1,56 @@
+name: Build Linux
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        required: true
+        type: string
+      binary:
+        required: true
+        type: string
+
+
+jobs:
+  github-releases:
+    name: linux
+    env:
+      platform: linux
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-unknown-linux-gnu
+
+      - name: install dependencies
+        run: |
+          sudo apt-get update; sudo apt-get install pkg-config libx11-dev libasound2-dev libudev-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev
+
+      - name: Build
+        run: |
+          cargo build --release --target x86_64-unknown-linux-gnu
+
+      - name: Set file name
+        id: set_file_name
+        run: |
+          echo "file_name=${{ inputs.binary }}_${{ inputs.tag }}_${{ env.platform }}" >> "$GITHUB_OUTPUT"
+
+      - name: Prepare package
+        run: |
+          mkdir linux
+          cp target/x86_64-unknown-linux-gnu/release/${{ inputs.binary }} linux/
+          cp -r assets linux/
+
+      - name: Package as a zip
+        working-directory: ./linux
+        run: |
+          zip --recurse-paths ../${{ steps.set_file_name.outputs.file_name  }}.zip .
+
+      - name: Upload binaries to artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ env.platform }}
+          path: ${{ steps.set_file_name.outputs.file_name  }}.zip
+          retention-days: 1

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -1,0 +1,103 @@
+name: Build MacOS
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        required: true
+        type: string
+      binary:
+        required: true
+        type: string
+      run_macos_intel:
+        required: true
+        type: string
+      run_macos_apple_silicon:
+        required: true
+        type: string
+
+
+jobs:
+  build-macos-intel:
+    if: inputs.run_macos_intel == 'true'
+    name: macos_intel
+    env:
+      platform: macos_intel
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-apple-darwin
+
+      - name: Environment Setup
+        run: |
+          export CFLAGS="-fno-stack-check"
+          export MACOSX_DEPLOYMENT_TARGET="10.9"
+
+      - name: Build
+        run: |
+          cargo build --release --target x86_64-apple-darwin
+
+      - name: Set Paths
+        id: set_paths
+        run: |
+          echo "file_name=${{ inputs.binary }}_${{ inputs.tag }}_${{ env.platform }}" >> "$GITHUB_OUTPUT"
+          echo "app_structure=${{ inputs.binary }}.app/Contents/MacOS" >> "$GITHUB_OUTPUT"
+
+      - name: Prepare Package
+        run: |
+          mkdir -p ${{ steps.set_paths.outputs.app_structure }}
+          cp target/x86_64-apple-darwin/release/${{ inputs.binary }} ${{ steps.set_paths.outputs.app_structure }}
+          cp -r assets ${{ steps.set_paths.outputs.app_structure }}
+          hdiutil create -fs HFS+ -volname "${{ inputs.binary }}" -srcfolder ${{ inputs.binary }}.app ${{ steps.set_paths.outputs.file_name  }}.dmg
+
+      - name: Upload binaries to artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ env.platform }}
+          path: ${{ steps.set_paths.outputs.file_name  }}.dmg
+          retention-days: 1
+        
+  build-macos-apple-silicon:
+    name: macos_apple_silicon
+    if: inputs.run_macos_apple_silicon == 'true'
+    env:
+      platform: macos_apple_silicon
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-darwin
+
+      - name: Environment
+        # macos 11 was the first version to support ARM
+        run: |
+          export MACOSX_DEPLOYMENT_TARGET="11"
+
+      - name: Build
+        run: |
+          cargo build --release --target aarch64-apple-darwin
+
+      - name: Set paths
+        id: set_paths
+        run: |
+          echo "file_name=${{ inputs.binary }}_${{ inputs.tag }}_${{ env.platform }}" >> "$GITHUB_OUTPUT"
+          echo "app_structure=${{ inputs.binary }}.app/Contents/MacOS" >> "$GITHUB_OUTPUT"
+
+      - name: Prepare Package
+        run: |
+          mkdir -p ${{ steps.set_paths.outputs.app_structure }}
+          cp target/aarch64-apple-darwin/release/${{ inputs.binary }} ${{ steps.set_paths.outputs.app_structure }}
+          cp -r assets ${{ steps.set_paths.outputs.app_structure }}
+          hdiutil create -fs HFS+ -volname "${{ inputs.binary }}" -srcfolder ${{ inputs.binary }}.app ${{ steps.set_paths.outputs.file_name  }}.dmg
+
+      - name: Upload binaries to artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ env.platform }}
+          path: ${{ steps.set_paths.outputs.file_name  }}.dmg
+          retention-days: 1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - '*'
+  workflow_dispatch:
 
 env:
   # update with the name of the main binary

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,17 +1,38 @@
 name: Release
 
+# Configure your build and release platforms
+env:
+  # If your repo name differs from your binary name, change it.
+  # Check you Cargo.toml -> package -> name
+  binary: ${{ github.event.repository.name }} 
+
+  # Build platforms
+  add_web: true
+  add_linux: true
+  add_windows: true
+  add_macos_intel: true
+  add_macos_apple_silicon: true
+
+  # Releases
+  
+  # Github release
+  add_github_release: true
+
+  # Itch.io
+  add_itchio_release: true
+  # Example of itchio_target: cart/build-a-better-buddy
+  # Check the url of your game page in itch.io
+  itchio_target: ameknite/bevy-game
+
+  # Github pages
+  add_github_pages_release: true
+
+
 on:
   push:
     tags:
       - '*'
   workflow_dispatch:
-
-env:
-  # update with the name of the main binary
-  binary: bevy_github_ci_template
-  add_binaries_to_github_release: true
-  #itch_target: <itch.io-username>/<game-name>
-
 
 jobs:
 
@@ -52,7 +73,7 @@ jobs:
           retention-days: 1
 
       - name: Upload binaries to release
-        if: ${{ env.add_binaries_to_github_release == 'true' }}
+        if: ${{ env.add_github_release == 'true' }}
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
@@ -99,7 +120,7 @@ jobs:
           retention-days: 1
 
       - name: Upload binaries to release
-        if: ${{ env.add_binaries_to_github_release == 'true' }}
+        if: ${{ env.add_github_release == 'true' }}
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
@@ -142,7 +163,7 @@ jobs:
           retention-days: 1
 
       - name: Upload binaries to release
-        if: ${{ env.add_binaries_to_github_release == 'true' }}
+        if: ${{ env.add_github_release == 'true' }}
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
@@ -186,7 +207,7 @@ jobs:
           retention-days: 1
 
       - name: Upload binaries to release
-        if: ${{ env.add_binaries_to_github_release == 'true' }}
+        if: ${{ env.add_github_release == 'true' }}
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
@@ -230,7 +251,7 @@ jobs:
           retention-days: 1
 
       - name: Upload binaries to release
-        if: ${{ env.add_binaries_to_github_release == 'true' }}
+        if: ${{ env.add_github_release == 'true' }}
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -78,7 +78,8 @@ jobs:
   load-env:
     runs-on: ubuntu-latest
     steps:
-      - id: check-itch-target
+      - name: check if itchio target exist
+        id : check-itchio-target
         run: |
           echo ${{env.binary}}
           if [[ -z ${{env.itchio_target || inputs.itchio_target}} ]]; then
@@ -99,7 +100,7 @@ jobs:
       run_github_release: ${{(inputs.tag && inputs.add_github_release) || (!inputs.tag && env.add_github_release)}}
       run_itchio_release: ${{(inputs.tag && inputs.add_itchio_release) || (!inputs.tag && env.add_itchio_release)}}
       run_github_pages_release: ${{(inputs.tag && inputs.add_github_pages_release) || (!inputs.tag && env.add_github_pages_release)}}
-      has_itchio_target: ${{steps.check-itch-target.outputs.target_exists}}
+      has_itchio_target: ${{steps.check-itchio-target.outputs.target_exists}}
       tag: ${{(inputs.tag || steps.get_version.outcome.tag)}}
 
   # Build for wasm

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,8 +33,46 @@ permissions:
 on:
   push:
     tags:
-      - '*'
+      - "*"
   workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Add tag version: (e.g. -> v3.6.1)'
+        required: true
+        type: string
+      add_web:
+        description: 'Build for Web:'
+        type: boolean
+        default: true
+      add_linux:
+        description: 'Build for Linux:'
+        type: boolean
+        default: true
+      add_windows:
+        description: 'Build for Windows:'
+        type: boolean
+        default: true
+      add_macos_intel:
+        description: 'Build for MacOS Intel'
+        type: boolean
+        default: true
+      add_macos_apple_silicon:
+        description: 'Build for MacOS Apple Silicon'
+        type: boolean
+        default: true
+      add_github_release:
+        description: 'Publish to Github Release'
+        type: boolean
+        default: true
+      add_github_pages_release:
+          description: 'Publish to Github Pages'
+          type: boolean
+      add_itchio_release:
+        description: 'Publish to Itch.io'
+        type: boolean
+      itchio_target:
+        description: 'Itchio target: <user>/<your-game>'
+        type: string
 
 jobs:
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,13 +19,13 @@ env:
   add_github_release: true
 
   # Itch.io
-  add_itchio_release: true
+  add_itchio_release: false
   # Example of itchio_target: cart/build-a-better-buddy
   # Check the url of your game page in itch.io
-  itchio_target: ameknite/bevy-game
+  # itchio_target: <user>/<your-game>
 
   # Github pages
-  add_github_pages_release: true
+  add_github_pages_release: false
 
 permissions:
   contents: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -56,6 +56,7 @@ on:
         type: string
 
 jobs:
+  # Load variables
   load-env:
     runs-on: ubuntu-latest
     steps:
@@ -66,249 +67,69 @@ jobs:
       run_build_web: ${{ ( inputs.tag &&  (contains(inputs.build_for, 'web') || contains(inputs.build_for, 'wasm')) ) || ( !inputs.tag && (contains(env.build_for, 'web') || contains(env.build_for, 'wasm')) ) }}
       run_build_linux: ${{ (inputs.tag && contains(inputs.build_for, 'linux')) || (!inputs.tag && contains(env.build_for, 'linux') ) }}
       run_build_windows: ${{ ( inputs.tag && contains(inputs.build_for, 'windows')) || (!inputs.tag && contains(env.build_for, 'windows') ) }}
-      run_build_macos_intel: ${{ ( inputs.tag && (contains(inputs.build_for, 'intel') || contains(inputs.build_for, 'macos')) ) || (!inputs.tag && (contains(env.build_for, 'intel') || contains(env.build_for, 'macos')) ) }}
+      run_build_macos: ${{ ( inputs.tag && contains(inputs.build_for, 'macos')) || (!inputs.tag && contains(env.build_for, 'macos') ) }}
+      run_build_macos_intel:  ${{ ( inputs.tag && ( contains(inputs.build_for, 'intel') || contains(inputs.build_for, 'macos') )) || (!inputs.tag && (contains(env.build_for, 'intel') || contains(env.build_for, 'macos')) ) }}
       run_build_macos_apple_silicon: ${{ ( inputs.tag && ( contains(inputs.build_for, 'apple') || contains(inputs.build_for, 'macos') )) || (!inputs.tag && (contains(env.build_for, 'apple') || contains(env.build_for, 'macos')) ) }}
       run_publish_github_releases: ${{ ( inputs.tag && contains(inputs.publish_to, 'releases')) || (!inputs.tag && contains(env.publish_to, 'releases') ) }}
       run_publish_itchio: ${{ ( inputs.tag && contains(inputs.publish_to, 'itchio')) || (!inputs.tag && contains(env.publish_to, 'itchio') ) }}
       run_publish_github_pages: ${{ ( inputs.tag && contains(inputs.publish_to, 'pages')) || (!inputs.tag && contains(env.publish_to, 'pages') ) }}
       itchio_target: ${{ inputs.itchio_target || env.itchio_target }}
       tag: ${{ ( inputs.tag || steps.get_version.outputs.tag ) }}
+      binary: ${{ env.binary }}
 
-  # Build for Web Wasm
+  # Build for Web/WASM
   build-web:
-    runs-on: ubuntu-latest
     needs: load-env
     if: needs.load-env.outputs.run_build_web == 'true'
-    env:
-      platform: web
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: wasm32-unknown-unknown
-
-      - name: install wasm-bindgen-cli
-        run: |
-          cargo install wasm-bindgen-cli
-
-      - name: Build
-        run: |
-          cargo build --release --target wasm32-unknown-unknown
-
-      - name: Set file name
-        id: set_file_name
-        run: |
-          echo "file_name=${{ env.binary }}_${{ needs.load-env.outputs.tag }}_${{ env.platform }}" >> "$GITHUB_OUTPUT"
-
-      - name: Prepare package
-        run: |
-          wasm-bindgen --no-typescript --out-name bevy_game --out-dir wasm --target web target/wasm32-unknown-unknown/release/${{ env.binary }}.wasm
-          cp -r assets wasm/
-
-      - name: Upload github-page to artifacts
-        if: needs.load-env.outputs.run_publish_github_pages == 'true'
-        uses: actions/upload-pages-artifact@v2
-        with:
-          path: ./wasm
-          retention-days: 1
-
-      - name: Package as a zip
-        working-directory: ./wasm
-        run: |
-          zip --recurse-paths ../${{ steps.set_file_name.outputs.file_name  }}.zip .
-
-      - name: Upload binaries to artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          name: ${{ env.platform }}
-          path: ${{ steps.set_file_name.outputs.file_name  }}.zip
-          retention-days: 1
+    uses: ./.github/workflows/web.yaml
+    name: build
+    with:
+      tag: ${{ needs.load-env.outputs.tag }}
+      binary: ${{ needs.load-env.outputs.binary }}
+      run_publish_github_pages: ${{ needs.load-env.outputs.run_publish_github_pages }}
 
   # Build for Linux x86_64
   build-linux:
-    runs-on: ubuntu-latest
     needs: load-env
     if: needs.load-env.outputs.run_build_linux == 'true'
-    env:
-      platform: linux
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: x86_64-unknown-linux-gnu
-
-      - name: install dependencies
-        run: |
-          sudo apt-get update; sudo apt-get install pkg-config libx11-dev libasound2-dev libudev-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev
-
-      - name: Build
-        run: |
-          cargo build --release --target x86_64-unknown-linux-gnu
-
-      - name: Set file name
-        id: set_file_name
-        run: |
-          echo "file_name=${{ env.binary }}_${{ needs.load-env.outputs.tag }}_${{ env.platform }}" >> "$GITHUB_OUTPUT"
-
-      - name: Prepare package
-        run: |
-          mkdir linux
-          cp target/x86_64-unknown-linux-gnu/release/${{ env.binary }} linux/
-          cp -r assets linux/
-
-      - name: Package as a zip
-        working-directory: ./linux
-        run: |
-          zip --recurse-paths ../${{ steps.set_file_name.outputs.file_name  }}.zip .
-
-      - name: Upload binaries to artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          name: ${{ env.platform }}
-          path: ${{ steps.set_file_name.outputs.file_name  }}.zip
-          retention-days: 1
+    uses: ./.github/workflows/linux.yaml
+    name: build
+    with:
+      tag: ${{ needs.load-env.outputs.tag }}
+      binary: ${{ needs.load-env.outputs.binary }}
 
   # Build for Windows x86_64
   build-windows:
-    runs-on: windows-latest
     needs: load-env
     if: needs.load-env.outputs.run_build_windows == 'true'
-    env:
-      platform: windows
-    steps:
-      - uses: actions/checkout@v4
+    uses: ./.github/workflows/windows.yaml
+    name: build
+    with:
+      tag: ${{ needs.load-env.outputs.tag }}
+      binary: ${{ needs.load-env.outputs.binary }}
 
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: x86_64-pc-windows-msvc
 
-      - name: Build
-        run: |
-          cargo build --release --target x86_64-pc-windows-msvc
-
-      - name: Set file name
-        id: set_file_name
-        shell: bash
-        run: |
-          echo "file_name=${{ env.binary }}_${{ needs.load-env.outputs.tag }}_${{ env.platform }}" >> "$GITHUB_OUTPUT"
-
-      - name: Prepare package
-        shell: bash
-        run: |
-          mkdir windows
-          cp target/x86_64-pc-windows-msvc/release/${{ env.binary }}.exe windows/
-          cp -r assets windows/
-
-      - name: Package as a zip
-        run: |
-          Compress-Archive -Path windows/* -DestinationPath "${{ steps.set_file_name.outputs.file_name  }}.zip"
-
-      - name: Upload binaries to artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          name: ${{ env.platform }}
-          path: ${{ steps.set_file_name.outputs.file_name  }}.zip
-          retention-days: 1
-
-  # Build for MacOS x86_64
-  build-macos-intel:
-    runs-on: macos-latest
+  # Build for MacOS x86_64/ARM64
+  build-macos:
     needs: load-env
-    if: needs.load-env.outputs.run_build_macos_intel == 'true'
-    env:
-      platform: macos_intel
-    steps:
-      - uses: actions/checkout@v4
+    if: needs.load-env.outputs.run_build_macos == 'true'
+    uses: ./.github/workflows/macos.yaml
+    name: build
+    with:
+      tag: ${{ needs.load-env.outputs.tag }}
+      binary: ${{ needs.load-env.outputs.binary }}
+      run_macos_intel: ${{ needs.load-env.outputs.run_build_macos_intel }}
+      run_macos_apple_silicon: ${{ needs.load-env.outputs.run_build_macos_apple_silicon }}
 
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: x86_64-apple-darwin
 
-      - name: Environment Setup
-        run: |
-          export CFLAGS="-fno-stack-check"
-          export MACOSX_DEPLOYMENT_TARGET="10.9"
-
-      - name: Build
-        run: |
-          cargo build --release --target x86_64-apple-darwin
-
-      - name: Set Paths
-        id: set_paths
-        run: |
-          echo "file_name=${{ env.binary }}_${{ needs.load-env.outputs.tag }}_${{ env.platform }}" >> "$GITHUB_OUTPUT"
-          echo "app_structure=${{ env.binary }}.app/Contents/MacOS" >> "$GITHUB_OUTPUT"
-
-      - name: Prepare Package
-        run: |
-          mkdir -p ${{ steps.set_paths.outputs.app_structure }}
-          cp target/x86_64-apple-darwin/release/${{ env.binary }} ${{ steps.set_paths.outputs.app_structure }}
-          cp -r assets ${{ steps.set_paths.outputs.app_structure }}
-          hdiutil create -fs HFS+ -volname "${{ env.binary }}" -srcfolder ${{ env.binary }}.app ${{ steps.set_paths.outputs.file_name  }}.dmg
-
-      - name: Upload binaries to artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          name: ${{ env.platform }}
-          path: ${{ steps.set_paths.outputs.file_name  }}.dmg
-          retention-days: 1
-
-  # Build for MacOS Apple Silicon
-  build-macos-apple-silicon:
-    runs-on: macos-latest
-    needs: load-env
-    if: needs.load-env.outputs.run_build_macos_apple_silicon == 'true'
-    env:
-      platform: macos_apple_silicon
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: aarch64-apple-darwin
-
-      - name: Environment
-        # macos 11 was the first version to support ARM
-        run: |
-          export MACOSX_DEPLOYMENT_TARGET="11"
-
-      - name: Build
-        run: |
-          cargo build --release --target aarch64-apple-darwin
-
-      - name: Set paths
-        id: set_paths
-        run: |
-          echo "file_name=${{ env.binary }}_${{ needs.load-env.outputs.tag }}_${{ env.platform }}" >> "$GITHUB_OUTPUT"
-          echo "app_structure=${{ env.binary }}.app/Contents/MacOS" >> "$GITHUB_OUTPUT"
-
-      - name: Prepare Package
-        run: |
-          mkdir -p ${{ steps.set_paths.outputs.app_structure }}
-          cp target/aarch64-apple-darwin/release/${{ env.binary }} ${{ steps.set_paths.outputs.app_structure }}
-          cp -r assets ${{ steps.set_paths.outputs.app_structure }}
-          hdiutil create -fs HFS+ -volname "${{ env.binary }}" -srcfolder ${{ env.binary }}.app ${{ steps.set_paths.outputs.file_name  }}.dmg
-
-      - name: Upload binaries to artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          name: ${{ env.platform }}
-          path: ${{ steps.set_paths.outputs.file_name  }}.dmg
-          retention-days: 1
-
-  # Release binaries in github
+  # Release binaries in GitHub
   publish-github-releases:
-    name: Release for ${{ matrix.artifact_name }}
     needs:
       - load-env
       - build-web
       - build-linux
       - build-windows
-      - build-macos-apple-silicon
-      - build-macos-intel
+      - build-macos
     if: ${{ always() && !failure() && !cancelled() && needs.load-env.outputs.run_publish_github_releases == 'true'}}
     strategy:
       fail-fast: false
@@ -324,92 +145,35 @@ jobs:
             os: macos-latest
           - artifact_name: macos_intel
             os: macos-latest
+    uses: ./.github/workflows/github_releases.yaml
+    name: publish / github-releases
+    with:
+      tag: ${{ needs.load-env.outputs.tag }}
+      os: ${{ matrix.os }}
+      artifact_name: ${{ matrix.artifact_name }}
+    secrets: inherit
 
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: xSAVIKx/artifact-exists-action@v0
-        id: check_artifact
-        with:
-          name: ${{ matrix.artifact_name }}
-
-      - name: Download artifacts
-        if: steps.check_artifact.outputs.exists == 'true'
-        uses: actions/download-artifact@v3
-        with:
-          name: ${{ matrix.artifact_name }}
-          path: ./artifact
-
-      - name: Get file
-        if: steps.check_artifact.outputs.exists == 'true'
-        id: get_file_name
-        shell: bash
-        working-directory: ./artifact
-        run: |
-          ls -R
-          echo "file_name=$(ls | head -n 1)" >> "$GITHUB_OUTPUT"
-
-      - name: Upload artifact to release
-        if: steps.check_artifact.outputs.exists == 'true'
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: ./artifact/${{ steps.get_file_name.outputs.file_name }}
-          tag: ${{ needs.load-env.outputs.tag }}
-          overwrite: true
-
-  # Publish to itch.io
+  # Publish to Itch.io
   publish-itchio:
-    runs-on: ubuntu-latest
     needs:
       - load-env
       - build-web
       - build-linux
       - build-windows
-      - build-macos-apple-silicon
-      - build-macos-intel
+      - build-macos
     if: ${{ always() && !failure() && !cancelled() && needs.load-env.outputs.run_publish_itchio == 'true' && needs.load-env.outputs.itchio_target != '' }}
-    steps:
-      - name: Download artifacts
-        uses: actions/download-artifact@v3
-        with:
-          path: ./builds
+    uses: ./.github/workflows/itchio.yaml
+    name: publish
+    with:
+      tag: ${{ needs.load-env.outputs.tag }}
+      itchio_target: ${{ needs.load-env.outputs.itchio_target }}
+    secrets: inherit
 
-      - name: Install butler
-        run: |
-          curl -L -o butler.zip https://broth.itch.ovh/butler/linux-amd64/LATEST/archive/default
-          unzip butler.zip
-          chmod +x butler
-          ./butler -V
-
-      - name: Upload to itch.io
-        env:
-          BUTLER_API_KEY: ${{ secrets.BUTLER_CREDENTIALS }}
-        run: |
-          for channel in $(ls builds); do
-            if [ "$channel" = "github-pages" ]; then
-              continue
-            fi
-            ./butler push \
-              --fix-permissions \
-              --userversion="${{ needs.load-env.outputs.tag }}" \
-              builds/$channel/* \
-              ${{ needs.load-env.outputs.itchio_target }}:$channel
-          done
-
-  # Publish to github page
+  # Publish to GitHub Pages
   publish-github-pages:
-    runs-on: ubuntu-latest
     needs:
       - load-env
       - build-web
     if: ${{ needs.load-env.outputs.run_publish_github_pages == 'true' }}
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - name: Setup Pages
-        uses: actions/configure-pages@v3
-
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v2
+    uses: ./.github/workflows/github_pages.yaml
+    name: publish

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -67,7 +67,6 @@ jobs:
       run_build_web: ${{ ( inputs.tag &&  (contains(inputs.build_for, 'web') || contains(inputs.build_for, 'wasm')) ) || ( !inputs.tag && (contains(env.build_for, 'web') || contains(env.build_for, 'wasm')) ) }}
       run_build_linux: ${{ (inputs.tag && contains(inputs.build_for, 'linux')) || (!inputs.tag && contains(env.build_for, 'linux') ) }}
       run_build_windows: ${{ ( inputs.tag && contains(inputs.build_for, 'windows')) || (!inputs.tag && contains(env.build_for, 'windows') ) }}
-      run_build_macos: ${{ ( inputs.tag && contains(inputs.build_for, 'macos')) || (!inputs.tag && contains(env.build_for, 'macos') ) }}
       run_build_macos_intel:  ${{ ( inputs.tag && ( contains(inputs.build_for, 'intel') || contains(inputs.build_for, 'macos') )) || (!inputs.tag && (contains(env.build_for, 'intel') || contains(env.build_for, 'macos')) ) }}
       run_build_macos_apple_silicon: ${{ ( inputs.tag && ( contains(inputs.build_for, 'apple') || contains(inputs.build_for, 'macos') )) || (!inputs.tag && (contains(env.build_for, 'apple') || contains(env.build_for, 'macos')) ) }}
       run_publish_github_releases: ${{ ( inputs.tag && contains(inputs.publish_to, 'releases')) || (!inputs.tag && contains(env.publish_to, 'releases') ) }}
@@ -112,7 +111,7 @@ jobs:
   # Build for MacOS x86_64/ARM64
   build-macos:
     needs: load-env
-    if: needs.load-env.outputs.run_build_macos == 'true'
+    if: needs.load-env.outputs.run_build_macos_intel == 'true' || needs.load-env.outputs.run_build_macos_apple_silicon == 'true'
     uses: ./.github/workflows/macos.yaml
     name: build
     with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,31 +4,36 @@ name: Release
 env:
   # If your repo name differs from your binary name, change it.
   # Check you Cargo.toml -> package -> name
-  binary: ${{ github.event.repository.name }} 
+  binary: ${{ github.event.repository.name }}
 
   # Build platforms
-  add_web: true
-  add_linux: true
-  add_windows: true
-  add_macos_intel: true
-  add_macos_apple_silicon: true
+
+  # Valid platforms: "web, linux, windows, macos_intel, macos_apple_silicon"
+  # - Write "intel" and "apple" to abbreviate "macos_intel" and "macos_apple_silicon," respectively.
+  # - Write "macos" to build for both "intel" and "apple"
+  # - Write "web" or "wasm" to build for the web
+  build_for: "web, linux, windows, macos"
 
   # Releases
-  
-  # Github release
-  add_github_release: true
 
-  # Itch.io
-  add_itchio_release: false
+  # Valid platforms: "github_releases, itchio, github_pages"
+  # - For brevity you can write: "releases, itchio, pages"
+  publish_to: "github_releases"
+
+  # Itch.io configuration
+
+  # itchio_target is REQUIRED for publish to itch.io to work.
+  itchio_target: #<user>/<your-game>
   # Example of itchio_target: cart/build-a-better-buddy
   # Check the url of your game page in itch.io
-  # itchio_target: <user>/<your-game>
-
-  # Github pages
-  add_github_pages_release: false
 
 permissions:
+  # To upload files to GitHub Releases
   contents: write
+  # To deploy to Pages
+  pages: write
+  # To verify the deployment originates from an appropriate source
+  id-token: write
 
 on:
   push:
@@ -37,77 +42,53 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Add tag version: (e.g. -> v3.6.1)'
+        description: "Add tag version: (e.g. -> v3.6.1)"
         required: true
         type: string
-      add_web:
-        description: 'Build for Web:'
-        type: boolean
-      add_linux:
-        description: 'Build for Linux:'
-        type: boolean
-      add_windows:
-        description: 'Build for Windows:'
-        type: boolean
-      add_macos_intel:
-        description: 'Build for MacOS Intel'
-        type: boolean
-      add_macos_apple_silicon:
-        description: 'Build for MacOS Apple Silicon'
-        type: boolean
-      add_github_release:
-        description: 'Publish to Github Release'
-        type: boolean
-      add_github_pages_release:
-          description: 'Publish to Github Pages'
-          type: boolean
-      add_itchio_release:
-        description: 'Publish to Itch.io'
-        type: boolean
+      build_for:
+        description: "Build for:"
+        default: web,linux,windows,macos
+      publish_to:
+        description: "Publish to:"
+        default: github_releases
       itchio_target:
-        description: 'Itchio target: <user>/<your-game>'
+        description: "Itchio target: <user>/<your-game>"
         type: string
 
 jobs:
   load-env:
     runs-on: ubuntu-latest
     steps:
-      - name: check if itchio target exist
-        id : check-itchio-target
-        run: |
-          echo ${{env.binary}}
-          if [[ -z ${{env.itchio_target || inputs.itchio_target}} ]]; then
-            echo "target_exists=false" >> $GITHUB_OUTPUT
-          else
-            echo "target_exists=true" >> $GITHUB_OUTPUT
-          fi
-
       - id: get_version
         uses: olegtarasov/get-tag@v2.1.2
 
     outputs:
-      run-build-web: ${{(inputs.tag && inputs.add_web) || (!inputs.tag && env.add_web)}}
-      run-build-linux: ${{(inputs.tag && inputs.add_linux) || (!inputs.tag && env.add_linux)}}
-      run-build-windows: ${{(inputs.tag && inputs.add_windows) || (!inputs.tag && env.add_windows)}}
-      run-build-macos-intel: ${{(inputs.tag && inputs.add_macos_intel) || (!inputs.tag && env.add_macos_apple_silicon)}}
-      run-build-macos-apple-silicon: ${{(inputs.tag && inputs.add_macos_apple_silicon) || (!inputs.tag && env.add_macos_apple_silicon)}}
-      run_github_release: ${{(inputs.tag && inputs.add_github_release) || (!inputs.tag && env.add_github_release)}}
-      run_itchio_release: ${{(inputs.tag && inputs.add_itchio_release) || (!inputs.tag && env.add_itchio_release)}}
-      run_github_pages_release: ${{(inputs.tag && inputs.add_github_pages_release) || (!inputs.tag && env.add_github_pages_release)}}
-      has_itchio_target: ${{steps.check-itchio-target.outputs.target_exists}}
-      tag: ${{(inputs.tag || steps.get_version.outcome.tag)}}
+      run_build_web: ${{ ( inputs.tag &&  (contains(inputs.build_for, 'web') || contains(inputs.build_for, 'wasm')) ) || ( !inputs.tag && (contains(env.build_for, 'web') || contains(env.build_for, 'wasm')) ) }}
+      run_build_linux: ${{ (inputs.tag && contains(inputs.build_for, 'linux')) || (!inputs.tag && contains(env.build_for, 'linux') ) }}
+      run_build_windows: ${{ ( inputs.tag && contains(inputs.build_for, 'windows')) || (!inputs.tag && contains(env.build_for, 'windows') ) }}
+      run_build_macos_intel: ${{ ( inputs.tag && (contains(inputs.build_for, 'intel') || contains(inputs.build_for, 'macos')) ) || (!inputs.tag && (contains(env.build_for, 'intel') || contains(env.build_for, 'macos')) ) }}
+      run_build_macos_apple_silicon: ${{ ( inputs.tag && ( contains(inputs.build_for, 'apple') || contains(inputs.build_for, 'macos') )) || (!inputs.tag && (contains(env.build_for, 'apple') || contains(env.build_for, 'macos')) ) }}
+      run_publish_github_releases: ${{ ( inputs.tag && contains(inputs.publish_to, 'releases')) || (!inputs.tag && contains(env.publish_to, 'releases') ) }}
+      run_publish_itchio: ${{ ( inputs.tag && contains(inputs.publish_to, 'itchio')) || (!inputs.tag && contains(env.publish_to, 'itchio') ) }}
+      run_publish_github_pages: ${{ ( inputs.tag && contains(inputs.publish_to, 'pages')) || (!inputs.tag && contains(env.publish_to, 'pages') ) }}
+      itchio_target: ${{ inputs.itchio_target || env.itchio_target }}
+      tag: ${{ ( inputs.tag || steps.get_version.outputs.tag ) }}
 
-  # Build for wasm
-  release-wasm:
+  # Build for Web Wasm
+  build-web:
     runs-on: ubuntu-latest
+    needs: load-env
+    if: needs.load-env.outputs.run_build_web == 'true'
+    env:
+      platform: web
 
     steps:
-      - uses: olegtarasov/get-tag@v2.1.2
-        id: get_version
       - uses: actions/checkout@v4
+
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown
+
       - name: install wasm-bindgen-cli
         run: |
           cargo install wasm-bindgen-cli
@@ -116,44 +97,49 @@ jobs:
         run: |
           cargo build --release --target wasm32-unknown-unknown
 
+      - name: Set file name
+        id: set_file_name
+        run: |
+          echo "file_name=${{ env.binary }}_${{ needs.load-env.outputs.tag }}_${{ env.platform }}" >> "$GITHUB_OUTPUT"
+
       - name: Prepare package
         run: |
           wasm-bindgen --no-typescript --out-name bevy_game --out-dir wasm --target web target/wasm32-unknown-unknown/release/${{ env.binary }}.wasm
           cp -r assets wasm/
 
+      - name: Upload github-page to artifacts
+        if: needs.load-env.outputs.run_publish_github_pages == 'true'
+        uses: actions/upload-pages-artifact@v2
+        with:
+          path: ./wasm
+          retention-days: 1
+
       - name: Package as a zip
         working-directory: ./wasm
         run: |
-          zip --recurse-paths ../${{ env.binary }}.zip .
+          zip --recurse-paths ../${{ steps.set_file_name.outputs.file_name  }}.zip .
 
       - name: Upload binaries to artifacts
         uses: actions/upload-artifact@v3
         with:
-          path: ${{ env.binary }}.zip
-          name: wasm
+          name: ${{ env.platform }}
+          path: ${{ steps.set_file_name.outputs.file_name  }}.zip
           retention-days: 1
 
-      - name: Upload binaries to release
-        if: ${{ env.add_github_release == 'true' }}
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: ${{ env.binary }}.zip
-          asset_name: ${{ env.binary }}-wasm-${{ steps.get_version.outputs.tag }}.zip
-          tag: ${{ github.ref }}
-          overwrite: true
-
-  # Build for Linux
-  release-linux:
+  # Build for Linux x86_64
+  build-linux:
     runs-on: ubuntu-latest
-
+    needs: load-env
+    if: needs.load-env.outputs.run_build_linux == 'true'
+    env:
+      platform: linux
     steps:
-      - uses: olegtarasov/get-tag@v2.1.2
-        id: get_version
       - uses: actions/checkout@v4
+
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: x86_64-unknown-linux-gnu
+
       - name: install dependencies
         run: |
           sudo apt-get update; sudo apt-get install pkg-config libx11-dev libasound2-dev libudev-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev
@@ -161,6 +147,11 @@ jobs:
       - name: Build
         run: |
           cargo build --release --target x86_64-unknown-linux-gnu
+
+      - name: Set file name
+        id: set_file_name
+        run: |
+          echo "file_name=${{ env.binary }}_${{ needs.load-env.outputs.tag }}_${{ env.platform }}" >> "$GITHUB_OUTPUT"
 
       - name: Prepare package
         run: |
@@ -171,33 +162,25 @@ jobs:
       - name: Package as a zip
         working-directory: ./linux
         run: |
-          zip --recurse-paths ../${{ env.binary }}.zip .
+          zip --recurse-paths ../${{ steps.set_file_name.outputs.file_name  }}.zip .
 
       - name: Upload binaries to artifacts
         uses: actions/upload-artifact@v3
         with:
-          path: ${{ env.binary }}.zip
-          name: linux
+          name: ${{ env.platform }}
+          path: ${{ steps.set_file_name.outputs.file_name  }}.zip
           retention-days: 1
 
-      - name: Upload binaries to release
-        if: ${{ env.add_github_release == 'true' }}
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: ${{ env.binary }}.zip
-          asset_name: ${{ env.binary }}-linux-${{ steps.get_version.outputs.tag }}.zip
-          tag: ${{ github.ref }}
-          overwrite: true
-
-  # Build for Windows
-  release-windows:
+  # Build for Windows x86_64
+  build-windows:
     runs-on: windows-latest
-
+    needs: load-env
+    if: needs.load-env.outputs.run_build_windows == 'true'
+    env:
+      platform: windows
     steps:
-      - uses: olegtarasov/get-tag@v2.1.2
-        id: get_version
       - uses: actions/checkout@v4
+
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: x86_64-pc-windows-msvc
@@ -206,7 +189,14 @@ jobs:
         run: |
           cargo build --release --target x86_64-pc-windows-msvc
 
+      - name: Set file name
+        id: set_file_name
+        shell: bash
+        run: |
+          echo "file_name=${{ env.binary }}_${{ needs.load-env.outputs.tag }}_${{ env.platform }}" >> "$GITHUB_OUTPUT"
+
       - name: Prepare package
+        shell: bash
         run: |
           mkdir windows
           cp target/x86_64-pc-windows-msvc/release/${{ env.binary }}.exe windows/
@@ -214,36 +204,29 @@ jobs:
 
       - name: Package as a zip
         run: |
-          Compress-Archive -Path windows/* -DestinationPath ${{ env.binary }}.zip
+          Compress-Archive -Path windows/* -DestinationPath "${{ steps.set_file_name.outputs.file_name  }}.zip"
 
       - name: Upload binaries to artifacts
         uses: actions/upload-artifact@v3
         with:
-          path: ${{ env.binary }}.zip
-          name: windows
+          name: ${{ env.platform }}
+          path: ${{ steps.set_file_name.outputs.file_name  }}.zip
           retention-days: 1
 
-      - name: Upload binaries to release
-        if: ${{ env.add_github_release == 'true' }}
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: ${{ env.binary }}.zip
-          asset_name: ${{ env.binary }}-windows-${{ steps.get_version.outputs.tag }}.zip
-          tag: ${{ github.ref }}
-          overwrite: true
-
   # Build for MacOS x86_64
-  release-macOS-intel:
-    runs-on: macOS-latest
-
+  build-macos-intel:
+    runs-on: macos-latest
+    needs: load-env
+    if: needs.load-env.outputs.run_build_macos_intel == 'true'
+    env:
+      platform: macos_intel
     steps:
-      - uses: olegtarasov/get-tag@v2.1.2
-        id: get_version
       - uses: actions/checkout@v4
+
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: x86_64-apple-darwin
+
       - name: Environment Setup
         run: |
           export CFLAGS="-fno-stack-check"
@@ -253,43 +236,42 @@ jobs:
         run: |
           cargo build --release --target x86_64-apple-darwin
 
+      - name: Set Paths
+        id: set_paths
+        run: |
+          echo "file_name=${{ env.binary }}_${{ needs.load-env.outputs.tag }}_${{ env.platform }}" >> "$GITHUB_OUTPUT"
+          echo "app_structure=${{ env.binary }}.app/Contents/MacOS" >> "$GITHUB_OUTPUT"
+
       - name: Prepare Package
         run: |
-          mkdir -p ${{ env.binary }}.app/Contents/MacOS
-          cp target/x86_64-apple-darwin/release/${{ env.binary }} ${{ env.binary }}.app/Contents/MacOS/
-          cp -r assets ${{ env.binary }}.app/Contents/MacOS/
-          hdiutil create -fs HFS+ -volname "${{ env.binary }}" -srcfolder ${{ env.binary }}.app ${{ env.binary }}-macOS-intel.dmg
+          mkdir -p ${{ steps.set_paths.outputs.app_structure }}
+          cp target/x86_64-apple-darwin/release/${{ env.binary }} ${{ steps.set_paths.outputs.app_structure }}
+          cp -r assets ${{ steps.set_paths.outputs.app_structure }}
+          hdiutil create -fs HFS+ -volname "${{ env.binary }}" -srcfolder ${{ env.binary }}.app ${{ steps.set_paths.outputs.file_name  }}.dmg
 
       - name: Upload binaries to artifacts
         uses: actions/upload-artifact@v3
         with:
-          path: ${{ env.binary }}-macOS-intel.dmg
-          name: macOS-intel
+          name: ${{ env.platform }}
+          path: ${{ steps.set_paths.outputs.file_name  }}.dmg
           retention-days: 1
 
-      - name: Upload binaries to release
-        if: ${{ env.add_github_release == 'true' }}
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file:  ${{ env.binary }}-macOS-intel.dmg
-          asset_name: ${{ env.binary }}-macOS-intel-${{ steps.get_version.outputs.tag }}.dmg
-          tag: ${{ github.ref }}
-          overwrite: true
-
   # Build for MacOS Apple Silicon
-  release-macOS-apple-silicon:
-    runs-on: macOS-latest
-
+  build-macos-apple-silicon:
+    runs-on: macos-latest
+    needs: load-env
+    if: needs.load-env.outputs.run_build_macos_apple_silicon == 'true'
+    env:
+      platform: macos_apple_silicon
     steps:
-      - uses: olegtarasov/get-tag@v2.1.2
-        id: get_version
       - uses: actions/checkout@v4
+
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: aarch64-apple-darwin
-      - name: Environment 
-        # macOS 11 was the first version to support ARM
+
+      - name: Environment
+        # macos 11 was the first version to support ARM
         run: |
           export MACOSX_DEPLOYMENT_TARGET="11"
 
@@ -297,54 +279,95 @@ jobs:
         run: |
           cargo build --release --target aarch64-apple-darwin
 
+      - name: Set paths
+        id: set_paths
+        run: |
+          echo "file_name=${{ env.binary }}_${{ needs.load-env.outputs.tag }}_${{ env.platform }}" >> "$GITHUB_OUTPUT"
+          echo "app_structure=${{ env.binary }}.app/Contents/MacOS" >> "$GITHUB_OUTPUT"
+
       - name: Prepare Package
         run: |
-          mkdir -p ${{ env.binary }}.app/Contents/MacOS
-          cp target/aarch64-apple-darwin/release/${{ env.binary }} ${{ env.binary }}.app/Contents/MacOS/
-          cp -r assets ${{ env.binary }}.app/Contents/MacOS/
-          hdiutil create -fs HFS+ -volname "${{ env.binary }}-macOS-apple-silicon" -srcfolder ${{ env.binary }}.app ${{ env.binary }}-macOS-apple-silicon.dmg
+          mkdir -p ${{ steps.set_paths.outputs.app_structure }}
+          cp target/aarch64-apple-darwin/release/${{ env.binary }} ${{ steps.set_paths.outputs.app_structure }}
+          cp -r assets ${{ steps.set_paths.outputs.app_structure }}
+          hdiutil create -fs HFS+ -volname "${{ env.binary }}" -srcfolder ${{ env.binary }}.app ${{ steps.set_paths.outputs.file_name  }}.dmg
 
       - name: Upload binaries to artifacts
         uses: actions/upload-artifact@v3
         with:
-          path: ${{ env.binary }}-macOS-apple-silicon.dmg
-          name: macOS-apple-silicon
+          name: ${{ env.platform }}
+          path: ${{ steps.set_paths.outputs.file_name  }}.dmg
           retention-days: 1
 
-      - name: Upload binaries to release
-        if: ${{ env.add_github_release == 'true' }}
+  # Release binaries in github
+  publish-github-releases:
+    name: Release for ${{ matrix.artifact_name }}
+    needs:
+      - load-env
+      - build-web
+      - build-linux
+      - build-windows
+      - build-macos-apple-silicon
+      - build-macos-intel
+    if: ${{ always() && !failure() && !cancelled() && needs.load-env.outputs.run_publish_github_releases == 'true'}}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - artifact_name: web
+            os: ubuntu-latest
+          - artifact_name: linux
+            os: ubuntu-latest
+          - artifact_name: windows
+            os: windows-latest
+          - artifact_name: macos_apple_silicon
+            os: macos-latest
+          - artifact_name: macos_intel
+            os: macos-latest
+
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: xSAVIKx/artifact-exists-action@v0
+        id: check_artifact
+        with:
+          name: ${{ matrix.artifact_name }}
+
+      - name: Download artifacts
+        if: steps.check_artifact.outputs.exists == 'true'
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ matrix.artifact_name }}
+          path: ./artifact
+
+      - name: Get file
+        if: steps.check_artifact.outputs.exists == 'true'
+        id: get_file_name
+        shell: bash
+        working-directory: ./artifact
+        run: |
+          ls -R
+          echo "file_name=$(ls | head -n 1)" >> "$GITHUB_OUTPUT"
+
+      - name: Upload artifact to release
+        if: steps.check_artifact.outputs.exists == 'true'
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: ${{ env.binary }}-macOS-apple-silicon.dmg
-          asset_name: ${{ env.binary }}-macOS-apple-silicon-${{ steps.get_version.outputs.tag }}.dmg
-          tag: ${{ github.ref }}
+          file: ./artifact/${{ steps.get_file_name.outputs.file_name }}
+          tag: ${{ needs.load-env.outputs.tag }}
           overwrite: true
 
-  check-if-upload-to-itch-is-configured:
-    runs-on: ubuntu-latest
-    outputs:
-      should-upload: ${{ steps.check-env.outputs.has-itch-target }}
-    steps:
-      - id: check-env
-        run: |
-          if [[ -z "$itch_target" ]]; then
-            echo "has-itch-target=no" >> $GITHUB_OUTPUT
-          else
-            echo "has-itch-target=yes" >> $GITHUB_OUTPUT
-          fi
-
-  upload-to-itch:
+  # Publish to itch.io
+  publish-itchio:
     runs-on: ubuntu-latest
     needs:
-      - check-if-upload-to-itch-is-configured
-      - release-wasm
-      - release-linux
-      - release-windows
-      - release-macOS-intel
-      - release-macOS-apple-silicon
-    if: ${{ needs.check-if-upload-to-itch-is-configured.outputs.should-upload == 'yes' }}
-
+      - load-env
+      - build-web
+      - build-linux
+      - build-windows
+      - build-macos-apple-silicon
+      - build-macos-intel
+    if: ${{ always() && !failure() && !cancelled() && needs.load-env.outputs.run_publish_itchio == 'true' && needs.load-env.outputs.itchio_target != '' }}
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v3
@@ -357,16 +380,36 @@ jobs:
           unzip butler.zip
           chmod +x butler
           ./butler -V
-      - uses: olegtarasov/get-tag@v2.1.2
-        id: get_version
+
       - name: Upload to itch.io
         env:
           BUTLER_API_KEY: ${{ secrets.BUTLER_CREDENTIALS }}
         run: |
           for channel in $(ls builds); do
+            if [ "$channel" = "github-pages" ]; then
+              continue
+            fi
             ./butler push \
-                --fix-permissions \
-                --userversion="${{ steps.get_version.outputs.tag }}" \
-                builds/$channel/* \
-                ${{ env.itch_target }}:$channel
+              --fix-permissions \
+              --userversion="${{ needs.load-env.outputs.tag }}" \
+              builds/$channel/* \
+              ${{ needs.load-env.outputs.itchio_target }}:$channel
           done
+
+  # Publish to github page
+  publish-github-pages:
+    runs-on: ubuntu-latest
+    needs:
+      - load-env
+      - build-web
+    if: ${{ needs.load-env.outputs.run_publish_github_pages == 'true' }}
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,27 +43,21 @@ on:
       add_web:
         description: 'Build for Web:'
         type: boolean
-        default: true
       add_linux:
         description: 'Build for Linux:'
         type: boolean
-        default: true
       add_windows:
         description: 'Build for Windows:'
         type: boolean
-        default: true
       add_macos_intel:
         description: 'Build for MacOS Intel'
         type: boolean
-        default: true
       add_macos_apple_silicon:
         description: 'Build for MacOS Apple Silicon'
         type: boolean
-        default: true
       add_github_release:
         description: 'Publish to Github Release'
         type: boolean
-        default: true
       add_github_pages_release:
           description: 'Publish to Github Pages'
           type: boolean

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -75,6 +75,32 @@ on:
         type: string
 
 jobs:
+  load-env:
+    runs-on: ubuntu-latest
+    steps:
+      - id: check-itch-target
+        run: |
+          echo ${{env.binary}}
+          if [[ -z ${{env.itchio_target || inputs.itchio_target}} ]]; then
+            echo "target_exists=false" >> $GITHUB_OUTPUT
+          else
+            echo "target_exists=true" >> $GITHUB_OUTPUT
+          fi
+
+      - id: get_version
+        uses: olegtarasov/get-tag@v2.1.2
+
+    outputs:
+      run-build-web: ${{(inputs.tag && inputs.add_web) || (!inputs.tag && env.add_web)}}
+      run-build-linux: ${{(inputs.tag && inputs.add_linux) || (!inputs.tag && env.add_linux)}}
+      run-build-windows: ${{(inputs.tag && inputs.add_windows) || (!inputs.tag && env.add_windows)}}
+      run-build-macos-intel: ${{(inputs.tag && inputs.add_macos_intel) || (!inputs.tag && env.add_macos_apple_silicon)}}
+      run-build-macos-apple-silicon: ${{(inputs.tag && inputs.add_macos_apple_silicon) || (!inputs.tag && env.add_macos_apple_silicon)}}
+      run_github_release: ${{(inputs.tag && inputs.add_github_release) || (!inputs.tag && env.add_github_release)}}
+      run_itchio_release: ${{(inputs.tag && inputs.add_itchio_release) || (!inputs.tag && env.add_itchio_release)}}
+      run_github_pages_release: ${{(inputs.tag && inputs.add_github_pages_release) || (!inputs.tag && env.add_github_pages_release)}}
+      has_itchio_target: ${{steps.check-itch-target.outputs.target_exists}}
+      tag: ${{(inputs.tag || steps.get_version.outcome.tag)}}
 
   # Build for wasm
   release-wasm:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,6 +27,8 @@ env:
   # Github pages
   add_github_pages_release: true
 
+permissions:
+  contents: write
 
 on:
   push:

--- a/.github/workflows/web.yaml
+++ b/.github/workflows/web.yaml
@@ -1,0 +1,64 @@
+name: Build Web
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        required: true
+        type: string
+      binary:
+        required: true
+        type: string
+      run_publish_github_pages:
+        required: true
+        type: string
+
+jobs:
+  github-releases:
+    name: web
+    env:
+      platform: web
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: install wasm-bindgen-cli
+        run: |
+          cargo install wasm-bindgen-cli
+
+      - name: Build
+        run: |
+          cargo build --release --target wasm32-unknown-unknown
+
+      - name: Set file name
+        id: set_file_name
+        run: |
+          echo "file_name=${{ inputs.binary }}_${{ inputs.tag }}_${{ env.platform }}" >> "$GITHUB_OUTPUT"
+
+      - name: Prepare package
+        run: |
+          wasm-bindgen --no-typescript --out-name bevy_game --out-dir wasm --target web target/wasm32-unknown-unknown/release/${{ inputs.binary }}.wasm
+          cp -r assets wasm/
+
+      - name: Upload github-page to artifacts
+        if: inputs.run_publish_github_pages == 'true'
+        uses: actions/upload-pages-artifact@v2
+        with:
+          path: ./wasm
+          retention-days: 1
+
+      - name: Package as a zip
+        working-directory: ./wasm
+        run: |
+          zip --recurse-paths ../${{ steps.set_file_name.outputs.file_name  }}.zip .
+
+      - name: Upload binaries to artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ env.platform }}
+          path: ${{ steps.set_file_name.outputs.file_name  }}.zip
+          retention-days: 1

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -1,0 +1,53 @@
+name: Build Windows
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        required: true
+        type: string
+      binary:
+        required: true
+        type: string
+
+
+jobs:
+  github-releases:
+    name: windows
+    env:
+      platform: windows
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-pc-windows-msvc
+
+      - name: Build
+        run: |
+          cargo build --release --target x86_64-pc-windows-msvc
+
+      - name: Set file name
+        id: set_file_name
+        shell: bash
+        run: |
+          echo "file_name=${{ inputs.binary }}_${{ inputs.tag }}_${{ env.platform }}" >> "$GITHUB_OUTPUT"
+
+      - name: Prepare package
+        shell: bash
+        run: |
+          mkdir windows
+          cp target/x86_64-pc-windows-msvc/release/${{ inputs.binary }}.exe windows/
+          cp -r assets windows/
+
+      - name: Package as a zip
+        run: |
+          Compress-Archive -Path windows/* -DestinationPath "${{ steps.set_file_name.outputs.file_name  }}.zip"
+
+      - name: Upload binaries to artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ env.platform }}
+          path: ${{ steps.set_file_name.outputs.file_name  }}.zip
+          retention-days: 1

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Definition: [.github/workflows/release.yaml](./.github/workflows/release.yaml)
 
 This workflow runs every time you push a tag to your repo.
 
-![Release workflow](https://github-production-user-asset-6210df.s3.amazonaws.com/104745335/270129182-904f75be-2e94-433c-956b-2b1758e9476a.png)
+![Release workflow](https://github-production-user-asset-6210df.s3.amazonaws.com/104745335/275751118-be1bb6da-dbf1-413d-8d8b-8d3ba92f4251.png)
 
 Example using git:
 
@@ -68,7 +68,7 @@ For example, `build_for: web, linux, macos` will build for the Web, Linux and Ma
 
 The build files will be uploaded to the artifacts section of their respective workflow runs. To access them, go to your GitHub repository, navigate to the `Actions` section, click on `Release` in the sidebar, select the `workflow run` triggered by your tag, and scroll down to find your artifacts.
 
-![Artifacts](https://github-production-user-asset-6210df.s3.amazonaws.com/104745335/268779709-2e1b3f0b-446b-40f1-8430-39583cb37cdd.png)
+![Artifacts](https://github-production-user-asset-6210df.s3.amazonaws.com/104745335/275743001-ce09f21c-3f3b-476d-a0a1-3f56ba2a46a9.png)
 
 ### Publish
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Definition: [.github/workflows/release.yaml](./.github/workflows/release.yaml)
 
 This workflow runs every time you push a tag to your repo.
 
-![Release workflow](https://user-images.githubusercontent.com/104745335/268805183-28e83868-fb19-4e5e-ae96-7553fa3ede3c.png)
+![Release workflow](https://github-production-user-asset-6210df.s3.amazonaws.com/104745335/270129182-904f75be-2e94-433c-956b-2b1758e9476a.png)
 
 Example using git:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Bevy GitHub CI Template
 
-Template for setting up continuous integration (CI) on a GitHub project for Bevy. This template enables you to test your code, build for the Web, Linux, Windows, MacOS, and publish to GitHub Releases, Itch.io, and GitHub Pages.
+Template for setting up continuous integration (CI) and continuous deployment (CD) on a GitHub project for Bevy. This template enables you to test your code, build for the Web, Linux, Windows, MacOS, and publish to GitHub Releases, Itch.io, and GitHub Pages.
 
 It creates two workflows:
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ You can build for the following platforms:
 
 By default, it builds for all platforms, but you can disable specific targets by setting their environment variable  `false` in the ([release.yaml](.github/workflows/release.yaml#L9)) file.
 
-For example, `add_windows: false` will skip the Windows build.
+For example, `build_windows: false` will skip the Windows build.
 
 The build files will be uploaded to the artifacts section of their respective workflow runs. To access them, go to your GitHub repository, navigate to the `Actions` section, click on `Release` in the sidebar, select the `workflow run` triggered by your tag, and scroll down to find your artifacts.
 
@@ -86,9 +86,9 @@ You can publish to the following platforms:
   - [License](#license)
   - [Contribution](#contribution)
 
-By default, it only publishes to GitHub Releases, but you can enable or disable any target by setting their environment variable to `true` or `false` in the ([release.yaml](.github/workflows/release.yaml#L16)) file.
+By default, it only publishes to GitHub Releases, but you can enable or disable any target by setting their environment variable to `true` or `false` in the ([release.yaml](.github/workflows/release.yaml#L19)) file.
 
-For example, `add_github_pages_release: true` will publish the web version of your game to GitHub Pages.
+For example, `publish_github_pages: true` will publish the web version of your game to GitHub Pages.
 
 Every time you trigger this workflow, it will upload the files for every platform you enable in the build process.
 
@@ -102,7 +102,7 @@ For example: `bevy-game_v3.6_linux.zip`
 
 ### Publish on Github Release
 
-This action will occur automatically every time you push a tag if you have enabled the environment variable `add_github_release: true` in the [release.yaml](./.github/workflows/release.yaml#L19) file.
+This action will occur automatically every time you push a tag if you have enabled the environment variable `publish_github_releases: true` in the [release.yaml](./.github/workflows/release.yaml#L28) file.
 
 However, if you prefer more configuration options to manage your releases, you can do so through the GitHub CLI or the web browser:
 
@@ -121,7 +121,7 @@ To publish to itch.io, follow this release flow:
 1. Create an API key at <https://itch.io/user/settings/api-keys>
 2. In your GitHub repository, go to the "Settings" tab, click on "Secrets" under the "Actions" section in the sidebar, and add a repository secret named `BUTLER_CREDENTIALS`, with the API key as its value.
 3. Create your game page on itch.io if you haven't already.
-4. In the [release.yaml](./.github/workflows/release.yaml#L22) file, set the environment variable `add_itchio_release: true`.
+4. In the [release.yaml](./.github/workflows/release.yaml#L22) file, set the environment variable `publish_itchio: true`.
 5. Uncomment the `env.itchio_target` in [release.yaml](./.github/workflows/release.yaml#L25) and set it to your itch.io username and the name of the game on itch.io, separated by a slash (`/`). For example: `cart/build-a-better-buddy`. Double-check the URL of your game to ensure the name is correct.
 
 Once these steps are completed, any tag pushed to GitHub will trigger an itch.io release, and it will use the tag as the [user version](https://itch.io/docs/butler/pushing.html#specifying-your-own-version-number).
@@ -139,7 +139,7 @@ Next, to make the game visible on your Itch.io page, go to your game's configura
 
 To publish on GitHub Pages, follow these steps:
 
-1. In the [release.yaml](./.github/workflows/release.yaml#L28) file, set the environment variable `add_github_pages_release: true` and the `add_web: true`.
+1. In the [release.yaml](./.github/workflows/release.yaml#L28) file, set the environment variable `publish_github_pages: true` and the `build_web: true`.
 2. Trigger the [release.yaml](./.github/workflows/release.yaml) workflow by pushing a tag.
 3. In your GitHub repository, go to the `Settings` tab, then click on `Pages` in the sidebar. Navigate to the `Build and Deployment` section, select the `gh-pages` branch and set the `root` folder. Finally, click on `Save`. ![Github Pages](https://github-production-user-asset-6210df.s3.amazonaws.com/104745335/268780368-af547adf-d8e8-4bdf-90e5-b7ee717493dc.png)
 4. Wait a few minutes and your page will be available at a URL following this structure: `https://<Your GitHub username>.github.io/<Name of your repository>/`

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ To publish on GitHub Pages, follow these steps:
 If you'd like to use the GitHub workflows provided here for your own project, you may need to make a few adjustments:
 
 1. For web builds, ensure that your project includes an `index.html` file under the `/wasm` directory.
-2. Make sure that the environment variable `binary` int ([release.yaml](.github/workflows/release.yaml#L7)) matches the name of your binary.
+2. Make sure that the name of your repository matches the name of your binary. If the name of your repository is different, simply change the environment variable `binary` in the ([release.yaml](.github/workflows/release.yaml#L7)) file to match the name of your binary.
 3. If your project doesn't have an `assets` folder:
     1. You can create one and add a `.gitkeep` file to it to enable you to push it to your repository.
     2. Alternatively, if your project does not use assets, you can remove the `cp -r assets` statements from the build jobs in the workflow.

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ To publish to itch.io, follow this release flow:
 Once these steps are completed, any tag pushed to GitHub will trigger an itch.io release, and it will use the tag as the [user version](https://itch.io/docs/butler/pushing.html#specifying-your-own-version-number).
 
 If you want to make your game playable directly on your Itch.io page, follow the steps above, and make sure to build it for the web by setting the environment variable `env.build_web: true`, or by checking the box labeled `Build for Web` when manually triggering the workflow in GitHub.
-Next, to make the game visible on your Itch.io page, go to your game's configuration on Itch.io, and change the `Kind of project`. Additionally, locate your uploaded web files and check the box that says, `This file will be played in the browser`."
+Next, to make the game visible on your Itch.io page, go to your game's configuration on Itch.io, and change the `Kind of project` to `HTML`. Additionally, locate your uploaded web files and check the box that says, `This file will be played in the browser`."
 
 
 ![Kind of project](https://user-images.githubusercontent.com/104745335/268805329-fb70e23e-44ee-4f2f-9d20-11d58ddeec9a.png)

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Once you complete the process, a new release will be available on GitHub, with t
 
 ### Publish on Itch.io
 
-To publish releases to itch.io, follow this release flow:
+To publish to itch.io, follow this release flow:
 
 1. Create an API key at <https://itch.io/user/settings/api-keys>
 2. In your GitHub repository, go to the "Settings" tab, click on "Secrets" under the "Actions" section in the sidebar, and add a repository secret named `BUTLER_CREDENTIALS`, with the API key as its value.
@@ -126,7 +126,9 @@ To publish releases to itch.io, follow this release flow:
 
 Once these steps are completed, any tag pushed to GitHub will trigger an itch.io release, and it will use the tag as the [user version](https://itch.io/docs/butler/pushing.html#specifying-your-own-version-number).
 
-To make the game visible on your itch.io page, go to your game's configuration on itch.io, and change the `Kind of project` to HTML also locate your uploaded web files, and check the box that says, `This file will be played in the browser`.
+If you want to make your game playable directly on your Itch.io page, follow the steps above, and make sure to build it for the web by setting the environment variable `env.build_web: true`, or by checking the box labeled `Build for Web` when manually triggering the workflow in GitHub.
+Next, to make the game visible on your Itch.io page, go to your game's configuration on Itch.io, and change the `Kind of project`. Additionally, locate your uploaded web files and check the box that says, `This file will be played in the browser`."
+
 
 ![Kind of project](https://user-images.githubusercontent.com/104745335/268805329-fb70e23e-44ee-4f2f-9d20-11d58ddeec9a.png)
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Next, to make the game visible on your Itch.io page, go to your game's configura
 
 To publish on GitHub Pages, follow these steps:
 
-1. In the [release.yaml](./.github/workflows/release.yaml#L28) file, set the environment variable `publish_github_pages: true` and the `build_web: true`.
+1. In the [release.yaml](./.github/workflows/release.yaml#L28) file, verify that both environment variables `publish_github_pages` and `build_web` are set to `true`.
 2. Trigger the [release.yaml](./.github/workflows/release.yaml) workflow by pushing a tag.
 3. In your GitHub repository, go to the `Settings` tab, then click on `Pages` in the sidebar. Navigate to the `Build and Deployment` section, select the `gh-pages` branch and set the `root` folder. Finally, click on `Save`. ![Github Pages](https://github-production-user-asset-6210df.s3.amazonaws.com/104745335/268780368-af547adf-d8e8-4bdf-90e5-b7ee717493dc.png)
 4. Wait a few minutes and your page will be available at a URL following this structure: `https://<Your GitHub username>.github.io/<Name of your repository>/`

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Next, to make the game visible on your Itch.io page, go to your game's configura
 
 ### Publish on Github pages
 
-To publish on GitHub Pages, follow these steps:
+If you want to publish your game to be playable in the browser on a [GitHub page](https://pages.github.com/) follow these steps:
 
 1. In the [release.yaml](./.github/workflows/release.yaml#L28) file, verify that both environment variables `publish_github_pages` and `build_web` are set to `true`.
 2. Trigger the [release.yaml](./.github/workflows/release.yaml) workflow by pushing a tag.

--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@ Definition: [.github/workflows/ci.yaml](./.github/workflows/ci.yaml)
 
 ![ci workflow](https://user-images.githubusercontent.com/104745335/268799840-06b772e8-7901-4b86-9a88-e4afee8a0167.png)
 
-
-This workflow runs on every commit to `main` branch, and on every PR targeting the `main` branch.
+This workflow runs on every commit to the `main` branch, and for every PR targeting the `main` branch.
 
 It will use Rust stable on Linux with caching between different executions. The following commands are executed:
 
@@ -41,17 +40,19 @@ git tag -a "v1.0.0" -m "First official release"
 git push --tags
 ```
 
-You can use the workflow as it is, but check that the name of your repository matches the name of your binary. If they don't match, you can change the environment variable in [release.yaml](.github/workflows/release.yaml#L7) file. By default it will build for the Web, Linux, Windows, and MacOS, and then it will publish the archives on GitHub Release.
+ By default, the workflow will build for the Web, Linux, Windows, and MacOS. The builds will be uploaded to a GitHub Release. If the name of your repository does not match the name of your binary, you should update the environment variable [`binary`](.github/workflows/release.yaml#L7) in the `release.yaml` file to your binary name.
 
-You can configure the builds and publish targets by changing the env variables in the [release.yaml](.github/workflows/release.yaml#L4) file.
+You can configure the [build](.github/workflows/release.yaml#L15) and [publish](.github/workflows/release.yaml#L21) targets by changing the [environment variables](.github/workflows/release.yaml#L4)  in the `release.yaml` file.
+
+#### Manual Workflow run in GitHub
 
 You can configure and trigger the workflow directly in your GitHub repository. Navigate to the `Actions` section, click `Release` on the sidebar, then press the `Run workflow` button and select the configuration for the build and publish targets you want.
 
-![Run workflow](https://github-production-user-asset-6210df.s3.amazonaws.com/104745335/268779376-85f4a503-1564-4075-b1ee-2a830fda2b7c.png)
+![Run manual workflow](https://user-images.githubusercontent.com/104745335/270079051-b5fb52c8-ed89-4f91-965e-670f38f87ddb.png)
 
-The configuration in GitHub takes priority over the env variables in the [release.yaml](.github/workflows/release.yaml#L4) file, so you don't have to modify your env variables. The manual workflow also enables you to override the tag version eliminating the need to create another tag to trigger the workflow."
+The configuration in GitHub takes priority over the environment variables in the [release.yaml](.github/workflows/release.yaml#L4) file. A manual workflow run also enables you to override the tag version eliminating the need to create a tag to trigger the workflow.
 
-For the itch.io target, you can leave it empty if you already have the environment variable set up.
+If you want to publish to itch.io, you will either have to configure the environment variable `itchio_target`, or define the `itchio_target` input for every run.
 
 ### Build
 
@@ -61,9 +62,9 @@ You can build for the following platforms:
 * For MacOS, generate two versions: one for Intel x86_64 and one for Apple Silicon ARM64, each packaged in a .dmg image containing a .app file with the assets.
 * For the Web, produce a .zip archive with the WebAssembly (wasm) binary, JavaScript bindings, an HTML file for loading it, and the assets.
 
-By default, it builds for all platforms, but you can disable specific targets by setting their environment variable  `false` in the ([release.yaml](.github/workflows/release.yaml#L9)) file.
+By default, it builds for all platforms, but you can disable specific targets by removing their name in the env variable [`build_for`](.github/workflows/release.yaml#L15) in the release.yaml file.
 
-For example, `build_windows: false` will skip the Windows build.
+For example, `build_for: web, linux, macos` will build for the Web, Linux and MacOS but will not build for windows.
 
 The build files will be uploaded to the artifacts section of their respective workflow runs. To access them, go to your GitHub repository, navigate to the `Actions` section, click on `Release` in the sidebar, select the `workflow run` triggered by your tag, and scroll down to find your artifacts.
 
@@ -73,22 +74,13 @@ The build files will be uploaded to the artifacts section of their respective wo
 
 You can publish to the following platforms:
 
-- [Bevy GitHub CI Template](#bevy-github-ci-template)
-  - [CI](#ci)
-  - [Release](#release)
-    - [Run Workflow](#run-workflow)
-    - [Build](#build)
-    - [Publish](#publish)
-    - [Publish on Github Release](#publish-on-github-release)
-    - [Publish on Itch.io](#publish-on-itchio)
-    - [Publish on Github pages](#publish-on-github-pages)
-  - [Adapting the Workflows for Your Project](#adapting-the-workflows-for-your-project)
-  - [License](#license)
-  - [Contribution](#contribution)
+* [Github Releases](#publish-to-github-releases)
+* [Itch.io](#publish-to-itchio)
+* [Github Pages](#publish-to-github-pages)
 
-By default, it only publishes to GitHub Releases, but you can enable or disable any target by setting their environment variable to `true` or `false` in the ([release.yaml](.github/workflows/release.yaml#L19)) file.
+By default, it only publishes to GitHub Releases, but you can enable or disable any target by writing or removing their name in the env variable [`publish_to`](.github/workflows/release.yaml#L21) in the release.yaml file.
 
-For example, `publish_github_pages: true` will publish the web version of your game to GitHub Pages.
+For example, `publish_github_pages: pages` will only publish the web version of your game to GitHub Pages.
 
 Every time you trigger this workflow, it will upload the files for every platform you enable in the build process.
 
@@ -100,9 +92,9 @@ The format will be .zip for web, Windows, and Linux, and .dmg for MacOS.
 
 For example: `bevy-game_v3.6_linux.zip`
 
-### Publish on Github Release
+### Publish to Github Releases
 
-This action will occur automatically every time you push a tag if you have enabled the environment variable `publish_github_releases: true` in the [release.yaml](./.github/workflows/release.yaml#L28) file.
+This action will occur automatically every time you push a tag if you have written `github_releases` to the env variable [`publish_to`](./.github/workflows/release.yaml#L28) in the release.yaml file.
 
 However, if you prefer more configuration options to manage your releases, you can do so through the GitHub CLI or the web browser:
 
@@ -111,45 +103,48 @@ However, if you prefer more configuration options to manage your releases, you c
 
 Once you complete the process, a new release will be available on GitHub, with the archives for each platform accessible as downloadable assets.
 
+If you want to publish by manually triggering a workflow in GitHub, instead of writing your env variables in the release.yaml file,  write all your configuration in the GitHub Workflow form and then run the workflow. Refer to the ['Manual Workflow Run in GitHub'](#manual-workflow-run-in-github)
+
 ![github release](https://user-images.githubusercontent.com/104745335/268805270-ff824032-4191-4528-9d45-a5511fef4f94.png)
 
-
-### Publish on Itch.io
+### Publish to Itch.io
 
 To publish to itch.io, follow this release flow:
 
 1. Create an API key at <https://itch.io/user/settings/api-keys>
-2. In your GitHub repository, go to the "Settings" tab, click on "Secrets" under the "Actions" section in the sidebar, and add a repository secret named `BUTLER_CREDENTIALS`, with the API key as its value.
+2. In your GitHub repository, go to the `Settings` tab, click on `Secrets` under the `Actions` section in the sidebar, and add a repository secret named `BUTLER_CREDENTIALS`, with the API key as its value.
 3. Create your game page on itch.io if you haven't already.
-4. In the [release.yaml](./.github/workflows/release.yaml#L22) file, set the environment variable `publish_itchio: true`.
-5. Uncomment the `env.itchio_target` in [release.yaml](./.github/workflows/release.yaml#L25) and set it to your itch.io username and the name of the game on itch.io, separated by a slash (`/`). For example: `cart/build-a-better-buddy`. Double-check the URL of your game to ensure the name is correct.
+4. In the release.yaml file, write  `itchio` in the env variable [`publish_to`](./.github/workflows/release.yaml#L21).
+5. Go to the env variable [`itchio_target`](./.github/workflows/release.yaml#L19) in the release.yaml and set it to your itch.io username and the name of the game on itch.io, separated by a slash (`/`). For example: `cart/build-a-better-buddy`. Double-check the URL of your game to ensure the name is correct.
 
 Once these steps are completed, any tag pushed to GitHub will trigger an itch.io release, and it will use the tag as the [user version](https://itch.io/docs/butler/pushing.html#specifying-your-own-version-number).
 
-If you want to make your game playable directly on your Itch.io page, follow the steps above, and make sure to build it for the web by setting the environment variable `env.build_web: true`, or by checking the box labeled `Build for Web` when manually triggering the workflow in GitHub.
-Next, to make the game visible on your Itch.io page, go to your game's configuration on Itch.io, and change the `Kind of project` to `HTML`. Additionally, locate your uploaded web files and check the box that says, `This file will be played in the browser`."
-
+If you want to make your game playable directly on your Itch.io page, follow the steps above, and make sure to build it for the web by writing `web` or `wasm` in the env variable [`publish_for`](./.github/workflows/release.yaml#L21).
+Next, to make the game visible on your Itch.io page, go to your game's configuration on Itch.io, and change the `Kind of project` to `HTML`. Additionally, locate your uploaded web files and check the box that says, `This file will be played in the browser`.
 
 ![Kind of project](https://user-images.githubusercontent.com/104745335/268805329-fb70e23e-44ee-4f2f-9d20-11d58ddeec9a.png)
 
-
 ![Play in browser](https://github-production-user-asset-6210df.s3.amazonaws.com/104745335/268780679-fa14874c-040b-41ff-8a04-71cf141970dc.png)
 
-### Publish on Github pages
+If you want to publish by manually triggering a workflow in GitHub, instead of doing the 4 and 5 steps, write all your configuration to in the GitHub Workflow form and then run the workflow. Refer to the ['Manual Workflow Run in GitHub'](#manual-workflow-run-in-github).
+
+### Publish to Github pages
 
 If you want to publish your game to be playable in the browser on a [GitHub page](https://pages.github.com/) follow these steps:
 
-1. In the [release.yaml](./.github/workflows/release.yaml#L28) file, verify that both environment variables `publish_github_pages` and `build_web` are set to `true`.
+1. In the release.yaml file, verify that you are writing `github_pages` to the env variable [`publish_to`](./.github/workflows/release.yaml#L21) and `web` in the env variable [`build_for`](./.github/workflows/release.yaml#L15).
 2. Trigger the [release.yaml](./.github/workflows/release.yaml) workflow by pushing a tag.
-3. In your GitHub repository, go to the `Settings` tab, then click on `Pages` in the sidebar. Navigate to the `Build and Deployment` section, select the `gh-pages` branch and set the `root` folder. Finally, click on `Save`. ![Github Pages](https://github-production-user-asset-6210df.s3.amazonaws.com/104745335/268780368-af547adf-d8e8-4bdf-90e5-b7ee717493dc.png)
+3. In your GitHub repository, go to the `Settings` tab, then click on `Pages` in the sidebar. Navigate to the `Build and Deployment` section and select `Github Actions` as the `Source`. ![Github Pages](https://user-images.githubusercontent.com/104745335/270078892-a6da763e-5a4a-4f55-8d3c-41a14e8423e2.png)
 4. Wait a few minutes and your page will be available at a URL following this structure: `https://<Your GitHub username>.github.io/<Name of your repository>/`
+
+If you want to publish by manually triggering a workflow in GitHub, instead of doing the 1 and 2 steps, write all your configuration in the GitHub Workflow form and then run the workflow. Refer to the ['Manual Workflow Run in GitHub'](#manual-workflow-run-in-github).
 
 ## Adapting the Workflows for Your Project
 
 If you'd like to use the GitHub workflows provided here for your own project, you may need to make a few adjustments:
 
 1. For web builds, ensure that your project includes an `index.html` file under the `/wasm` directory.
-2. Make sure that the name of your repository matches the name of your binary. If the name of your repository is different, simply change the environment variable `binary` in the ([release.yaml](.github/workflows/release.yaml#L7)) file to match the name of your binary.
+2. Make sure that the name of your repository matches the name of your binary. If the name of your repository is different, simply change the env variable [`binary`](.github/workflows/release.yaml#L7) in the release.yaml file to match the name of your binary.
 3. If your project doesn't have an `assets` folder:
     1. You can create one and add a `.gitkeep` file to it to enable you to push it to your repository.
     2. Alternatively, if your project does not use assets, you can remove the `cp -r assets` statements from the build jobs in the workflow.

--- a/README.md
+++ b/README.md
@@ -1,83 +1,148 @@
 # Bevy GitHub CI Template
 
-This repo show how to set up CI on a GitHub project for Bevy.
+Template for setting up continuous integration (CI) on a GitHub project for Bevy. This template enables you to test your code, build for the Web, Linux, Windows, MacOS, and publish to GitHub Releases, Itch.io, and GitHub Pages.
 
 It creates two workflows:
 
-* [CI](#CI)
-* [Release](#Release)
+* [CI](#ci)
+* [Release](#release)
 
 ## CI
 
 Definition: [.github/workflows/ci.yaml](./.github/workflows/ci.yaml)
 
+![Screenshot 2023-09-18 at 17 53 05](https://user-images.githubusercontent.com/104745335/268799840-06b772e8-7901-4b86-9a88-e4afee8a0167.png)
+
+
 This workflow runs on every commit to `main` branch, and on every PR targeting the `main` branch.
 
-It will use rust stable on linux, with cache between different executions, those commands:
+It will use Rust stable on Linux with caching between different executions. The following commands are executed:
 
 * `cargo test`
 * `cargo clippy -- -D warnings`
 * `cargo fmt --all -- --check`
 
-If you are using anything OS specific or rust nightly, you should update the file [ci.yaml](./.github/workflows/ci.yaml) to use those.
+If you are using anything OS-specific or Rust nightly, you should update the [ci.yaml](./.github/workflows/ci.yaml) file  accordingly.
 
 ## Release
 
 Definition: [.github/workflows/release.yaml](./.github/workflows/release.yaml)
 
-This workflow runs on every tag.
+### Run Workflow
 
-It will build:
-* For Linux and Windows, a .zip archive containing the executable and the `assets`.
-* For macOS, a dmg image with a .app containing the assets.
-* For wasm, a .zip archive with the wasm binary, the js bindings, an html file loading it, and the assets.
+This workflow runs every time you push a tag to your repo.
 
-If you don't want to target some of those platforms, you can remove the corresponding job from the file [release.yaml](./.github/workflows/release.yaml).
-
-If you don't want to attach the builds to the GitHub release, set `env.add_binaries_to_github_release` to `false`.
-
-### Git Tag from GitHub UI
-
-You can follow [Managing releases in a repository](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository)
-
-### Git Tag from the CLI
-
-Execute the following commands: 
+Example using git:
 
 ```sh
-git tag -a "my-game-1.0" -m "First official release"
+git tag -a "v1.0.0" -m "First official release"
 git push --tags
 ```
 
-### Result
+You can use the workflow as it is, but check that the name of your repository matches the name of your binary. If they don't match, you can change the environment variable in [release.yaml](.github/workflows/release.yaml#L7) file. By default it will build for the Web, Linux, Windows, and MacOS, and then it will publish the archives on GitHub Release.
 
-A new release will be available in GitHub, with the archives per platform available as downloadable assets.
+You can configure the builds and publish targets by changing the env variables in the [release.yaml](.github/workflows/release.yaml#L4) file.
 
-The `git` commands above produced this release: [my-game-1.0](
-https://github.com/bevyengine/bevy_github_ci_template/releases/tag/my-game-1.0).
+Also you can configure and triggered the workflow directly in your GitHub repo. Navigate to the `Actions` section, click `Release` on the sidebar, then press the `Run workflow` button and select the configuration for the build and publish targets you want.
 
-## Using the workflows in your own project
+![Run workflow](https://github-production-user-asset-6210df.s3.amazonaws.com/104745335/268779376-85f4a503-1564-4075-b1ee-2a830fda2b7c.png)
 
-If you would like to use the GitHub workflows included here for your own project, there are a few things you might have to adapt:
+The configuration in GitHub takes priority over the env variables in the [release.yaml](.github/workflows/release.yaml#L4) file, so you don't have to modify your env variables. The manual workflow also enables you to override the tag version eliminating the need to create another tag to trigger the workflow."
 
-1. The release workflow relies on the `index.html` file under `/wasm` for web builds
-2. Make sure that the env variable `binary` ([release.yaml](.github/workflows/release.yaml#L10)) matches the name of your binary
-3. In case your project doesn't have an `assets` folder
-   1. Either create one and put a `.gitkeep` file in it to be able to push it
-   2. Or remove the `cp -r assets` statements in the build jobs
-4. Adapt the used toolchain if you are using nightly
-5. In your GitHub repo's settings, under `Actions -> General` make sure "Read and Write permissions" is selected under "Workflow permissions" near the bottom. This fixes the error `Error: Resource not accessible by integration`.
+### Build
 
+You can build for the following platforms:
 
-### Publish on itch.io
+* For Linux and Windows, create a .zip archive containing the executable and the `assets` folder.
+* For MacOS, generate two versions: one for Intel x86_64 and one for Apple Silicon ARM64, each packaged in a .dmg image containing a .app file with the assets.
+* For the Web, produce a .zip archive with the WebAssembly (wasm) binary, JavaScript bindings, an HTML file for loading it, and the assets.
 
-The release flow can be configured to push the releases to itch.io:
+By default, it builds for all platforms, but you can disable specific targets by setting their environment variable  `false` in the ([release.yaml](.github/workflows/release.yaml#L9)) file.
 
-1. Create an API key in https://itch.io/user/settings/api-keys
-2. Go to the repository's Settings tab in GitHub, click on Secrets->Actions in the sidebar,and add a repository secret named `BUTLER_CREDENTIALS` set to the API key.
-3. Uncomment `env.itch_target` in `release.yaml` and set it to the itch.io username and the name of the game on itch.io, separated by a slash (`/`)
+For example, `add_windows: false` will skip the Windows build.
 
-Once that is done, any tag pushed to GitHub will trigger an itch.io release and use the tag as the [user version](https://itch.io/docs/butler/pushing.html#specifying-your-own-version-number).
+The build files will be uploaded to the artifacts section of their respective workflow runs. To access them, go to your GitHub repository, navigate to the `Actions` section, click on `Release` in the sidebar, select the `workflow run` triggered by your tag, and scroll down to find your artifacts.
+
+![Artifacts](https://github-production-user-asset-6210df.s3.amazonaws.com/104745335/268779709-2e1b3f0b-446b-40f1-8430-39583cb37cdd.png)
+
+### Publish
+
+You can publish to the following platforms:
+
+- [Bevy GitHub CI Template](#bevy-github-ci-template)
+  - [CI](#ci)
+  - [Release](#release)
+    - [Run Workflow](#run-workflow)
+    - [Build](#build)
+    - [Publish](#publish)
+    - [Publish on Github Release](#publish-on-github-release)
+    - [Publish on Itch.io](#publish-on-itchio)
+    - [Publish on Github pages](#publish-on-github-pages)
+  - [Adapting the Workflows for Your Project](#adapting-the-workflows-for-your-project)
+  - [License](#license)
+  - [Contribution](#contribution)
+
+By default, it only publishes to GitHub Releases, but you can enable or disable any target by setting their environment variable to `true` or `false` in the ([release.yaml](.github/workflows/release.yaml#L16)) file.
+
+For example, `add_github_pages_release: true` will publish the web version of your game to GitHub Pages.
+
+Every time you trigger this workflow, it will upload the files for every platform you enable in the build process.
+
+The naming convention for the uploaded files will follow this structure:
+
+`<Name of your binary>_<tag>_<platform>.<format>`
+
+The format will be .zip for web, Windows, and Linux, and .dmg for MacOS.
+
+For example: `bevy-game_v3.6_linux.zip`
+
+### Publish on Github Release
+
+This action will occur automatically every time you push a tag if you have enabled the environment variable `add_github_release: true` in the [release.yaml](./.github/workflows/release.yaml#L19) file.
+
+However, if you prefer more configuration options to manage your releases, you can do so through the GitHub CLI or the web browser:
+
+1. [Github CLI](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository?tool=cli): You can use `gh release create` to create a GitHub release iteratively from your terminal.
+2. [Web Browser](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository?tool=webui)
+
+Once you complete the process, a new release will be available on GitHub, with the archives for each platform accessible as downloadable assets.
+
+### Publish on Itch.io
+
+To publish releases to itch.io, follow this release flow:
+
+1. Create an API key at <https://itch.io/user/settings/api-keys>
+2. In your GitHub repository, go to the "Settings" tab, click on "Secrets" under the "Actions" section in the sidebar, and add a repository secret named `BUTLER_CREDENTIALS`, with the API key as its value.
+3. Create your game page on itch.io if you haven't already.
+4. In the [release.yaml](./.github/workflows/release.yaml#L22) file, set the environment variable `add_itchio_release: true`.
+5. Uncomment the `env.itchio_target` in [release.yaml](./.github/workflows/release.yaml#L25) and set it to your itch.io username and the name of the game on itch.io, separated by a slash (`/`). For example: `cart/build-a-better-buddy`. Double-check the URL of your game to ensure the name is correct.
+
+Once these steps are completed, any tag pushed to GitHub will trigger an itch.io release, and it will use the tag as the[user version](https://itch.io/docs/butler/pushing.html#specifying-your-own-version-number).
+
+To make the game visible on your itch.io page, go to your game's configuration on itch.io, and change the `Kind of project` to HTML also locate your uploaded web files, and check the box that says, `This file will be played in the browser`.
+
+![Play in browser](https://github-production-user-asset-6210df.s3.amazonaws.com/104745335/268780679-fa14874c-040b-41ff-8a04-71cf141970dc.png)
+
+### Publish on Github pages
+
+To publish on GitHub Pages, follow these steps:
+
+1. In the [release.yaml](./.github/workflows/release.yaml#L28) file, set the environment variable `add_github_pages_release: true` and the `add_web: true`.
+2. Trigger the [release.yaml](./.github/workflows/release.yaml) workflow by pushing a tag.
+3. In your GitHub repository, go to the `Settings` tab, then click on `Pages` in the sidebar. Navigate to the `Build and Deployment` section, select the `gh-pages` branch and set the `root` folder. Finally, click on `Save`. ![Github Pages](https://github-production-user-asset-6210df.s3.amazonaws.com/104745335/268780368-af547adf-d8e8-4bdf-90e5-b7ee717493dc.png)
+4. Wait a few minutes and your page will be available at a URL following this structure: `https://<Your GitHub username>.github.io/<Name of your repository>/`
+
+## Adapting the Workflows for Your Project
+
+If you'd like to use the GitHub workflows provided here for your own project, you may need to make a few adjustments:
+
+1. For web builds, ensure that your project includes an `index.html` file under the `/wasm` directory.
+2. Make sure that the environment variable `binary` int ([release.yaml](.github/workflows/release.yaml#L7)) matches the name of your binary.
+3. If your project doesn't have an `assets` folder:
+    1. You can create one and add a `.gitkeep` file to it to enable you to push it to your repository.
+    2. Alternatively, if your project does not use assets, you can remove the `cp -r assets` statements from the build jobs in the workflow.
+4. If you are using a nightly toolchain or a specific Rust version, make sure to adapt the toolchain version as needed.
+5. If you encounter the error `Error: Resource not accessible by integration,`. Go to your GitHub repository's settings, and under `Actions -> General,` ensure that `Read and Write permissions` are selected under `Workflow permissions` near the bottom.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ To publish releases to itch.io, follow this release flow:
 4. In the [release.yaml](./.github/workflows/release.yaml#L22) file, set the environment variable `add_itchio_release: true`.
 5. Uncomment the `env.itchio_target` in [release.yaml](./.github/workflows/release.yaml#L25) and set it to your itch.io username and the name of the game on itch.io, separated by a slash (`/`). For example: `cart/build-a-better-buddy`. Double-check the URL of your game to ensure the name is correct.
 
-Once these steps are completed, any tag pushed to GitHub will trigger an itch.io release, and it will use the tag as the[user version](https://itch.io/docs/butler/pushing.html#specifying-your-own-version-number).
+Once these steps are completed, any tag pushed to GitHub will trigger an itch.io release, and it will use the tag as the [user version](https://itch.io/docs/butler/pushing.html#specifying-your-own-version-number).
 
 To make the game visible on your itch.io page, go to your game's configuration on itch.io, and change the `Kind of project` to HTML also locate your uploaded web files, and check the box that says, `This file will be played in the browser`.
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ You can use the workflow as it is, but check that the name of your repository ma
 
 You can configure the builds and publish targets by changing the env variables in the [release.yaml](.github/workflows/release.yaml#L4) file.
 
-Also you can configure and triggered the workflow directly in your GitHub repo. Navigate to the `Actions` section, click `Release` on the sidebar, then press the `Run workflow` button and select the configuration for the build and publish targets you want.
+You can configure and trigger the workflow directly in your GitHub repository. Navigate to the `Actions` section, click `Release` on the sidebar, then press the `Run workflow` button and select the configuration for the build and publish targets you want.
 
 ![Run workflow](https://github-production-user-asset-6210df.s3.amazonaws.com/104745335/268779376-85f4a503-1564-4075-b1ee-2a830fda2b7c.png)
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It creates two workflows:
 
 Definition: [.github/workflows/ci.yaml](./.github/workflows/ci.yaml)
 
-![Screenshot 2023-09-18 at 17 53 05](https://user-images.githubusercontent.com/104745335/268799840-06b772e8-7901-4b86-9a88-e4afee8a0167.png)
+![ci workflow](https://user-images.githubusercontent.com/104745335/268799840-06b772e8-7901-4b86-9a88-e4afee8a0167.png)
 
 
 This workflow runs on every commit to `main` branch, and on every PR targeting the `main` branch.
@@ -32,6 +32,8 @@ Definition: [.github/workflows/release.yaml](./.github/workflows/release.yaml)
 
 This workflow runs every time you push a tag to your repo.
 
+![Release workflow](https://user-images.githubusercontent.com/104745335/268805183-28e83868-fb19-4e5e-ae96-7553fa3ede3c.png)
+
 Example using git:
 
 ```sh
@@ -48,6 +50,8 @@ Also you can configure and triggered the workflow directly in your GitHub repo. 
 ![Run workflow](https://github-production-user-asset-6210df.s3.amazonaws.com/104745335/268779376-85f4a503-1564-4075-b1ee-2a830fda2b7c.png)
 
 The configuration in GitHub takes priority over the env variables in the [release.yaml](.github/workflows/release.yaml#L4) file, so you don't have to modify your env variables. The manual workflow also enables you to override the tag version eliminating the need to create another tag to trigger the workflow."
+
+For the itch.io target, you can leave it empty if you already have the environment variable set up.
 
 ### Build
 
@@ -107,6 +111,9 @@ However, if you prefer more configuration options to manage your releases, you c
 
 Once you complete the process, a new release will be available on GitHub, with the archives for each platform accessible as downloadable assets.
 
+![github release](https://user-images.githubusercontent.com/104745335/268805270-ff824032-4191-4528-9d45-a5511fef4f94.png)
+
+
 ### Publish on Itch.io
 
 To publish releases to itch.io, follow this release flow:
@@ -120,6 +127,9 @@ To publish releases to itch.io, follow this release flow:
 Once these steps are completed, any tag pushed to GitHub will trigger an itch.io release, and it will use the tag as the[user version](https://itch.io/docs/butler/pushing.html#specifying-your-own-version-number).
 
 To make the game visible on your itch.io page, go to your game's configuration on itch.io, and change the `Kind of project` to HTML also locate your uploaded web files, and check the box that says, `This file will be played in the browser`.
+
+![Kind of project](https://user-images.githubusercontent.com/104745335/268805329-fb70e23e-44ee-4f2f-9d20-11d58ddeec9a.png)
+
 
 ![Play in browser](https://github-production-user-asset-6210df.s3.amazonaws.com/104745335/268780679-fa14874c-040b-41ff-8a04-71cf141970dc.png)
 


### PR DESCRIPTION
This PR improves the release workflow by adding:

* Manual workflow dispatch
* Setting environment variables to specify the desired build and release platforms.
* Separating build and release jobs
* Adding deployment to GitHub Pages.

This also improves the README and addresses (#14).

I tested it, and it works in this repository:
https://github.com/ameknite/bevy_game
itch.io page:
https://ameknite.itch.io/bevy-game
github pages:
https://ameknite.github.io/bevy_game/