### PR TITLE
Update html template css to better handle full screen canvas window

### DIFF
--- a/wasm/index.html
+++ b/wasm/index.html
@@ -1,7 +1,11 @@
 <!doctype html>
 <html lang="en">
-
-<body style="margin: 0px;">
+<head>
+  <style>
+    html, body {margin:0;height:100%;}
+  </style>
+</head>
+<body>
   <script type="module">
     import './restart-audio-context.js'
     import init from './bevy_game.js'


### PR DESCRIPTION
Update css in index.html according to the discussion https://github.com/bevyengine/bevy/pull/4726 under the heading **Easy "fullscreen window" mode for the default canvas**.

Before this change setting window option `fit_canvas_to_parent` to `true` and building for the web will result in the canvas element growing vertically each time the window is resized regardless if the window is made wider or narrower. Also the canvas element height is not adjusted correctly if loaded in a browser window with a height is less than the canvas height.

With this change the canvas element grows and fits the browser window as expected, not least if published to itch.io and loaded in a mobile web browser.