### PR TITLE
Ignore meta files check using `AssetMetaCheck`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,4 @@ opt-level = 1
 opt-level = 3
 
 [dependencies]
-bevy = "0.11"
+bevy = "0.12"

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,10 +4,12 @@
 // Feel free to delete this line.
 #![allow(clippy::too_many_arguments, clippy::type_complexity)]
 
+use bevy::asset::AssetMetaCheck;
 use bevy::prelude::*;
 
 fn main() {
     App::new()
+        .insert_resource(AssetMetaCheck::Never)
         .add_plugins(DefaultPlugins)
         .add_systems(Startup, setup)
         .run();

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,9 @@ use bevy::prelude::*;
 
 fn main() {
     App::new()
+        // Wasm builds will check for meta files (that don't exist) if this isn't set.
+        // This causes errors and even panics on web build on itch.
+        // See https://github.com/bevyengine/bevy_github_ci_template/issues/48.
         .insert_resource(AssetMetaCheck::Never)
         .add_plugins(DefaultPlugins)
         .add_systems(Startup, setup)


### PR DESCRIPTION
Addresses the issue of wasm build not working correclty and itch panicking because of missing meta files that don't exist, #48.