### PR TITLE
Update cache action to v4 in Github CI workflow jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v4
       - name: Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/
@@ -44,7 +44,7 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v4
       - name: Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/


### PR DESCRIPTION
Node.js 16 actions such as "actions/cache@v3" have been deprecated. See https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/