### PR TITLE
Update to Bevy 0.14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,4 @@ opt-level = 1
 opt-level = 3
 
 [dependencies]
-bevy = "0.12"
+bevy = "0.14"

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,11 +9,13 @@ use bevy::prelude::*;
 
 fn main() {
     App::new()
-        // Wasm builds will check for meta files (that don't exist) if this isn't set.
-        // This causes errors and even panics on web build on itch.
-        // See https://github.com/bevyengine/bevy_github_ci_template/issues/48.
-        .insert_resource(AssetMetaCheck::Never)
-        .add_plugins(DefaultPlugins)
+        .add_plugins(DefaultPlugins.set(AssetPlugin {
+            // Wasm builds will check for meta files (that don't exist) if this isn't set.
+            // This causes errors and even panics in web builds on itch.
+            // See https://github.com/bevyengine/bevy_github_ci_template/issues/48.
+            meta_check: AssetMetaCheck::Never,
+            ..default()
+        }))
         .add_systems(Startup, setup)
         .run();
 }


### PR DESCRIPTION
Bumps the version of Bevy used and fixes the resulting breakage.

Tested building for macos / web.