### PR TITLE
Update to Bevy 0.15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,4 @@ opt-level = 1
 opt-level = 3
 
 [dependencies]
-bevy = "0.14"
+bevy = "0.15"

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,9 +21,9 @@ fn main() {
 }
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
-    commands.spawn(Camera2dBundle::default());
-    commands.spawn(SpriteBundle {
-        texture: asset_server.load("ducky.png"),
+    commands.spawn(Camera2d);
+    commands.spawn(Sprite {
+        image: asset_server.load("ducky.png"),
         ..Default::default()
     });
 }


### PR DESCRIPTION
Bumps the version of Bevy used and fixes the resulting breakage.

Tested building for macos / web.