### PR TITLE
Change Outdated Butler Host Link

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -285,7 +285,7 @@ jobs:
 
       - name: Install butler
         run: |
-          curl -L -o butler.zip https://broth.itch.ovh/butler/linux-amd64/LATEST/archive/default
+          curl -L -o butler.zip https://broth.itch.zone/butler/linux-amd64/LATEST/archive/default
           unzip butler.zip
           chmod +x butler
           ./butler -V


### PR DESCRIPTION
Related to https://github.com/itchio/butler/issues/283

Currently release.yaml has outdated install host `broth.itch.ovh`. New host is `broth.itch.zone`, which is the only change in this PR.