### PR TITLE
feat(ci): parse wasm-bindgen version to install correct client

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,7 +29,7 @@ jobs:
           override: true
       - name: install wasm-bindgen-cli
         run: |
-          cargo install wasm-bindgen-cli
+          cargo install -f wasm-bindgen-cli  --version 0.2.106
 
       - name: Build
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,7 +29,8 @@ jobs:
           override: true
       - name: install wasm-bindgen-cli
         run: |
-          cargo install -f wasm-bindgen-cli  --version 0.2.106
+          version=`cargo metadata --format-version 1 | jq --raw-output '.packages[] | select(.name=="wasm-bindgen") | .version'`
+          cargo install -f wasm-bindgen-cli --version $version
 
       - name: Build
         run: |


### PR DESCRIPTION
Fix #83 
Prevent wasm CI from crashing when a Cargo.lock is committed and a new version of wasm-bindgen-cli is released, effectively installed via its name only in CI, but incompatible with the old one from the lockfile.

This PR addresses this by parsing cargo metadata and installing the same version.